### PR TITLE
[SMD-43]: update base html

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 # TODO
 
-- [ ] extend base.html to login
+- [X] extend base.html to login
 - [ ] change reference on login from sharepoint to ???
 - [ ] update upload.html to follow design

--- a/app/static/src/css/custom.css
+++ b/app/static/src/css/custom.css
@@ -1,3 +1,7 @@
 .govuk-footer__copyright-logo {
     background-image: url("/static/images/govuk-crest.png")
 }
+
+.govuk-main-wrapper {
+    padding-top: 15px;
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -17,16 +17,33 @@
 {% endblock head %}
 
 {% block header %}
-  {{ govukHeader({
-    'homepageUrl': url_for('main.index'),
-    'serviceUrl': url_for('main.index'),
-    'navigation': [
-    {
-      'href': config['AUTHENTICATOR_HOST'] + "/sso/logout",
-      'text': 'Log out',
-    },
-  ]
-  }) }}
+  {% if g.user %}
+    {{ govukHeader({
+      'homepageUrl': url_for('main.index'),
+      'serviceUrl': url_for('main.index'),
+      'navigation': [
+      {
+        'href': url_for('main.index'),
+        'text': config['SERVICE_NAME'],
+      },
+      {
+        'href': config['AUTHENTICATOR_HOST'] + "/sso/logout",
+        'text': 'Log out',
+      },
+    ]
+    }) }}
+  {% else %}
+    {{ govukHeader({
+      'homepageUrl': url_for('main.index'),
+      'serviceUrl': url_for('main.index'),
+      'navigation': [
+      {
+        'href': url_for('main.index'),
+        'text': config['SERVICE_NAME'],
+      },
+    ]
+    }) }}
+  {% endif %}
 {% endblock header %}
 
 {% block beforeContent %}
@@ -44,17 +61,6 @@
     <div class="govuk-width-container ">
       <div class="govuk-footer__meta">
         <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-          <div class="govuk-!-margin-bottom-6">
-            <h2 class="govuk-heading-l">Get help</h2>
-            <p class="govuk-body">If you are experiencing difficulties with this service or have any questions, you can email us.</p>
-            <h3 class="govuk-heading-m">Email</h3>
-            <p class="govuk-body"><a class="govuk-link" href="mailto:FSD.Support@levellingup.gov.uk">fsd.support@levellingup.gov.uk</a></p>
-            <p class="govuk-body">Monday to Friday: 9am to 5pm (except public holidays).</p>
-            <h2 class="govuk-visually-hidden">Support links</h2>
-          </div>
-          <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
-            <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"></path>
-          </svg>
           <span class="govuk-footer__licence-description">
             All content is available under the
             <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated

--- a/app/templates/main/login.html
+++ b/app/templates/main/login.html
@@ -1,23 +1,10 @@
+{% extends "base.html" %}
+
 {%- from 'govuk_frontend_jinja/components/button/macro.html' import govukButton -%}
-{%- from 'govuk_frontend_jinja/components/header/macro.html' import govukHeader -%}
-{%- from 'govuk_frontend_jinja/components/phase-banner/macro.html' import govukPhaseBanner -%}
-{%- from 'govuk_frontend_jinja/components/footer/macro.html' import govukFooter -%}
 
-{% block head %}
-  <meta name="description" content="{{ config['SERVICE_NAME'] }}">
-  <meta name="keywords" content="GOV.UK, govuk, gov, government, uk, frontend, ui, user interface, jinja, python, flask, port, template, templating, macro, component, design system, html, forms, wtf, wtforms, widget, widgets, demo, example">
-  <meta name="author" content="{{ config['DEPARTMENT_NAME'] }}">
-  <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='govuk-frontend-4.7.0.min.css') }}" />
-  {% assets "css" %}<link href="{{ ASSET_URL }}" rel="stylesheet">{% endassets %}
-{% endblock head %}
-
-{% block header %}
-  {{ govukHeader({
-    'homepageUrl': url_for('main.index'),
-    'serviceName': 'Submit monitoring and evaluation',
-    'serviceUrl': url_for('main.index'),
-  }) }}
-{% endblock header %}
+{% block beforeContent %}
+{{ super() }}
+{% endblock beforeContent %}
 
 {% block content %}
 
@@ -34,7 +21,7 @@
             "classes": "login-button"
         }) }}
 
-        <h2 class="govuk-heading-l govuk-!-margin-top-4">Get help</h2>
+        <h2 class="govuk-heading-l govuk-!-margin-top-4">Trouble signing in</h2>
         <p class="govuk-body">If you need help, email us at <a class="govuk-link" href="mailto:FSD.Support@levellingup.gov.uk">fsd.support@levellingup.gov.uk</a>. Do not send your data return or any attachments using the help email.</p>
         </div>
     </section>
@@ -42,11 +29,3 @@
 </main>
 
 {% endblock content %}
-
-{{ govukFooter({}) }}
-
-{% block bodyEnd %}
-  <script src="{{ url_for('static', filename='govuk-frontend-4.7.0.min.js') }}"> </script>
-  <script>window.GOVUKFrontend.initAll()</script>
-  {% assets "js" %}<script type="text/javascript" src="{{ ASSET_URL }}"></script>{% endassets %}
-{% endblock bodyEnd %}


### PR DESCRIPTION
- Updates base.html so that the footer reflects the design
- Overwrites padding-top for main wrapper to prevent large white space between phase banner and content

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

Footer now corresponds to design specification on all pages, such as below:

<img width="497" alt="image" src="https://github.com/communitiesuk/funding-service-design-post-award-submit/assets/35725316/ba960cf9-22fc-4553-b15e-8f7b544a3e07">


