### PR TITLE
User friendly error presentation

### DIFF
--- a/app/templates/main/errorAccordion.html
+++ b/app/templates/main/errorAccordion.html
@@ -1,0 +1,21 @@
+{% macro errorAccordion(tab_errors) %}.
+    <div class="govuk-accordion" data-module="govuk-accordion">
+        {% for tab in tab_errors %}
+            <div class="govuk-accordion__section">
+                <div class="govuk-accordion__section-header">
+                    <h2 class="govuk-accordion__section-heading">
+                        <span class="govuk-accordion__section-button">{{ tab }}</span>
+                    </h2>
+                </div>
+                {% for section in tab_errors[tab] %}
+                    <div class="govuk-accordion__section-content">
+                        <h3 class="govuk-heading-s">{{ section }}</h3>
+                        {% for error in tab_errors[tab][section] %}
+                            <p class="govuk-body">{{ error }}</p>
+                        {% endfor %}
+                    </div>
+                {% endfor %}
+            </div>
+        {% endfor %}
+    </div>
+{% endmacro %}

--- a/app/templates/main/success.html
+++ b/app/templates/main/success.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+
+{%- from 'govuk_frontend_jinja/components/panel/macro.html' import govukPanel -%}
+
+{% block beforeContent %}
+{{ super() }}
+{% endblock beforeContent %}
+
+{% block content %}
+    <main id="main-content" role="main">
+        <section class="govuk-main-wrapper">
+            <div class="govuk-width-container">
+
+                {{ govukPanel({
+                "titleHtml": "Return submitted",
+                "text": file_name
+                }) }}
+
+                <h2 class="govuk-heading-l">What happens next</h2>
+                <p class="govuk-body">We will only contact you using the email you’ve provided, if we need to:</p>
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>talk to you about your spreadsheet</li>
+                    <li>ask questions about the data you’ve submitted</li>
+                </ul>
+                <p class="govuk-body">If you need to contact us, you can do so by using this (email) {{ config['CONTACT_EMAIL'] }}.</p>
+            </div>
+        </section>
+    </main>
+{% endblock content %}

--- a/app/templates/main/upload.html
+++ b/app/templates/main/upload.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 
 {%- from 'govuk_frontend_jinja/components/file-upload/macro.html' import govukFileUpload -%}
+{%- from 'govuk_frontend_jinja/components/button/macro.html' import govukButton -%}
+{%- from "govuk_frontend_jinja/components/accordion/macro.html" import govukAccordion -%}
+{%- from "errorAccordion.html" import errorAccordion -%}
 
 {% block beforeContent %}
 {{ super() }}
@@ -8,15 +11,41 @@
 
 {% block content %}
 
-    <form method="post" action="{{ url_for('main.upload') }}" enctype="multipart/form-data">
-        {{ govukFileUpload({'id': 'ingest_spreadsheet', 'label': {'text': 'Upload a file'}, 'name': 'ingest_spreadsheet'}) }}
-        <input type="submit" value="Upload" />
-    </form>
+    <main id="main-content" role="main">
+        <section class="govuk-main-wrapper">
+            <div class="govuk-width-container">
 
-    {% if response %}
-        {% for message in response %}
-            <p> {{ message }} </p>
-        {% endfor %}
-    {% endif %}
+                {% if not tab_errors %}
+                    <h1 class="govuk-heading-xl">Get ready to submit your monitoring and evaluation data return</h1>
+                {% else %}
+                    <h2 class="govuk-heading-l">There are errors in your return</h2>
+                    <p class="govuk-body">The following errors have been found in your return. You need to fix them before you resubmit your file.</p>
+                    {{ errorAccordion(tab_errors) }}
+                {% endif %}
+
+                <div class="upload-data-container">
+                    <form method="post" action="{{ url_for('main.upload') }}" enctype="multipart/form-data">
+                        {% if not pre_error %}
+                            {{ govukFileUpload({'id': 'ingest_spreadsheet',
+                             "hint": {"text": "Upload a .csv"},
+                             "label": {"text": ""},
+                             'name': 'ingest_spreadsheet'}) }}
+                        {% else %}
+                            {{ govukFileUpload({'id': 'ingest_spreadsheet',
+                             "hint": {"text": "Upload a .csv"},
+                             "label": {"text": ""},
+                             "errorMessage": {"text": pre_error[0]},
+                             'name': 'ingest_spreadsheet'}) }}
+                        {% endif %}
+                        {{ govukButton({"element": "button",
+                        "text": "Continue",
+                        "attributes": {
+                            "aria-controls": "example-id",
+                            "data-tracking-dimension": 123} }) }}
+                    </form>
+                </div>
+            </div>
+        </section>
+    </main>
 
 {% endblock content %}

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -22,7 +22,7 @@ class DefaultConfig(object):
     SERVICE_PHASE = os.environ.get("SERVICE_PHASE", "BETA")
     SERVICE_URL = os.environ.get("SERVICE_URL", "dev-service-url")
     SESSION_COOKIE_SECURE = True
-    DATA_STORE_API_HOST = os.environ.get("DATA_STORE_API_HOST")
+    DATA_STORE_API_HOST = os.environ.get("DATA_STORE_API_HOST", "http://localhost:8080")
 
     # Funding Service Design Post Award
     FSD_USER_TOKEN_COOKIE_NAME = "fsd_user_token"


### PR DESCRIPTION
Currently all errors are raised on the back end, collated, and surfaced here. The code handles this by deliniating the status_code of thee responce then checking for any PreTransformationErrors and TabErrors contained in the responce body that need to be surfaced in one of three ways:

Three paths for error handling added:
- Happy path: Sucessfull upload
Status_code = 200
No errors returned. renders a seperate html page success.html where the user is informed of their success and they can log off the service
![image](https://github.com/communitiesuk/funding-service-design-post-award-submit/assets/63752812/005a0122-e00c-4e08-9f30-4830c9f3785b)

- Unhappy path 1: Pre validation errors
Status_code = 400
Error that stops spreedsheet ingestion from being attempted e.g wrong file type, Invalid tabs in the spreedsheet, or an invalid organisation name. Prompts user to re-upload
Renders on page using the file upload error message
![Screenshot 2023-08-23 at 13-24-35 Submit monitoring and evaluation data – GOV UK](https://github.com/communitiesuk/funding-service-design-post-award-submit/assets/63752812/4d1944a0-66aa-4d65-8142-695f1afe49fe)

- Unhappy path 2: Validation errors
Status_code = 400
Errors raised during spreedsheet ingestion due to invalid entries these will be surfaced in an accordion to present the information to the user. A custom version of the govukAccordion macro is used as the number and length of accordian sections varies based on the number of errors returned. We loop over each error for every tab to be displayed per accordion section.
<img width="502" alt="Screenshot 2023-08-23 132145" src="https://github.com/communitiesuk/funding-service-design-post-award-submit/assets/63752812/34785b23-3898-4d16-89ec-55d7a477471a">