### PR TITLE
BAU: fix margins

### DIFF
--- a/app/static/src/css/custom.css
+++ b/app/static/src/css/custom.css
@@ -5,3 +5,9 @@
 .govuk-main-wrapper {
     padding-top: 15px;
 }
+
+@media (min-width:48.0625em) {
+    .govuk-main-wrapper {
+      padding-right: 170px;
+    }
+  }


### PR DESCRIPTION
Fixes right-margin such that pages now have the same margins as designs in: https://www.figma.com/file/eU00tDFeRbGx4PCN1uFBHW/%2F%2F-Submit-%2F%2F-October-2023-TF-Deliverable?type=design&node-id=145-1674&mode=design&t=Vmyeo9rH6BURCdEW-0


- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


Before:

<img width="959" alt="Screenshot 2023-08-21 155900" src="https://github.com/communitiesuk/funding-service-design-post-award-submit/assets/35725316/7f43f3ec-7088-4658-a330-d4be26d582e7">

After:

<img width="959" alt="Screenshot 2023-08-21 160410" src="https://github.com/communitiesuk/funding-service-design-post-award-submit/assets/35725316/60144802-69ba-4640-ba6c-60b8ccd6e42c">
