### PR TITLE
[SMD-80] handle 500 errors from the data-store

### DIFF
--- a/app/main/data_requests.py
+++ b/app/main/data_requests.py
@@ -25,7 +25,7 @@ def post_ingest(file: FileStorage, data: dict = None) -> Response:
 
     response = requests.post(request_url, files=files, data=data)
 
-    if response.status_code in [200, 400]:
+    if response.status_code in [200, 400, 500]:
         return response
 
     else:

--- a/app/templates/main/uncaughtValidation.html
+++ b/app/templates/main/uncaughtValidation.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block pageTitle %}Sorry, there is a problem with the service – {{ config['SERVICE_NAME'] }} – GOV.UK{% endblock pageTitle %}
+
+{% set mainClasses = "govuk-main-wrapper--l" %}
+
+{% block content %}
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
+        <p class="govuk-body">Try again later.</p>
+        <p class="govuk-body">Contact us at <a href="mailto:{{ config['CONTACT_EMAIL'] }}">{{ config['CONTACT_EMAIL'] }}</a>. Do not send your return or any attachments using the help email.</p>
+    </div>
+</div>
+{% endblock content %}

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -11,7 +11,7 @@ from fsd_utils import configclass
 class DefaultConfig(object):
     FLASK_ROOT = str(Path(__file__).parent.parent.parent)
 
-    CONTACT_EMAIL = os.environ.get("CONTACT_EMAIL", "FSD.Support@levellingup.gov.uk")
+    CONTACT_EMAIL = os.environ.get("CONTACT_EMAIL", "fsd.support@levellingup.gov.uk")
     CONTACT_PHONE = os.environ.get("CONTACT_PHONE", "12345678910")
     DEPARTMENT_NAME = os.environ.get("DEPARTMENT_NAME", "Department for Levelling Up, Housing and Communities")
     DEPARTMENT_URL = os.environ.get(

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -94,6 +94,23 @@ def test_upload_xlsx_validation_errors(requests_mock, example_pre_ingest_data_fi
     assert "Start date in an incorrect format. Please enter a dates in the format 'Dec-22'" in str(page_html)
 
 
+def test_upload_xlsx_uncaught_validation_error(requests_mock, example_pre_ingest_data_file, flask_test_client):
+    requests_mock.post(
+        "http://data-store/ingest",
+        content=b'"detail": "Uncaught workbook validation failure", "status": 500, "title": "Bad Request"',
+        status_code=500,
+    )
+    response = flask_test_client.post("/upload", data={"ingest_spreadsheet": example_pre_ingest_data_file})
+    page_html = BeautifulSoup(response.data)
+    service_email = flask_test_client.application.config["CONTACT_EMAIL"]
+
+    assert response.status_code == 200
+    assert (
+        f'Contact us at <a href="mailto:{service_email}">{service_email}</a>. Do not '
+        "send your return or any attachments using the help email."
+    ) in str(page_html)
+
+
 def test_upload_wrong_format(flask_test_client, example_ingest_wrong_format):
     response = flask_test_client.post("/upload", data={"ingest_spreadsheet": example_ingest_wrong_format})
     page_html = BeautifulSoup(response.data)


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/jira/software/c/projects/SMD/boards/140?modal=detail&selectedIssue=SMD-80

### Change description
Handle 500 errors from the data-store by displaying a page that prompts the user to contact FSD support to help with their submission. This occurs when there is an uncaught exception during ingest - which can happen for various reasons.

- [X] Unit tests and other appropriate tests added or updated
- [X] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
