### PR TITLE
[SMD-111] Modify existing error screen for uncaught validation error

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -27,7 +27,7 @@ def upload():
         excel_file = request.files.get("ingest_spreadsheet")
         file_format = excel_file.content_type
         if file_format != MIMETYPE.XLSX:
-            error = [f"Unexpected file format: {file_format}"]
+            error = ["The file selected must be an Excel file"]
             return render_template("upload.html", pre_error=error)
 
         ingest_response = post_ingest(excel_file, {"source_type": "tf_round_four"})

--- a/app/templates/main/uncaughtValidation.html
+++ b/app/templates/main/uncaughtValidation.html
@@ -9,7 +9,7 @@
     <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
         <p class="govuk-body">Try again later.</p>
-        <p class="govuk-body">Contact us at <a href="mailto:{{ config['CONTACT_EMAIL'] }}">{{ config['CONTACT_EMAIL'] }}</a>. Do not send your return or any attachments using the help email.</p>
+        <p class="govuk-body">Your error code is [XXXX]. Please email us on <a href="mailto:{{ config['CONTACT_EMAIL'] }}">{{ config['CONTACT_EMAIL'] }}</a> and include this error code, so we can investigate this issue and complete your submission</p>
     </div>
 </div>
 {% endblock content %}

--- a/app/templates/main/upload.html
+++ b/app/templates/main/upload.html
@@ -41,7 +41,7 @@
                              'name': 'ingest_spreadsheet'}) }}
                         {% else %}
                             {{ govukFileUpload({'id': 'ingest_spreadsheet',
-                             "hint": {"text": "Upload a CSV file"},
+                             "hint": {"text": "Upload a Excel file"},
                              "label": {"text": ""},
                              "errorMessage": {"text": pre_error[0]},
                              'name': 'ingest_spreadsheet'}) }}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -126,8 +126,8 @@ def test_upload_xlsx_uncaught_validation_error(requests_mock, example_pre_ingest
 
     assert response.status_code == 200
     assert (
-        f'Contact us at <a href="mailto:{service_email}">{service_email}</a>. Do not '
-        "send your return or any attachments using the help email."
+        f'Your error code is [XXXX]. Please email us on <a href="mailto:{service_email}">{service_email}</a> and '
+        f"include this error code, so we can investigate this issue and complete your submission"
     ) in str(page_html)
 
 
@@ -135,4 +135,4 @@ def test_upload_wrong_format(flask_test_client, example_ingest_wrong_format):
     response = flask_test_client.post("/upload", data={"ingest_spreadsheet": example_ingest_wrong_format})
     page_html = BeautifulSoup(response.data)
     assert response.status_code == 200
-    assert "Unexpected file format:" in str(page_html)
+    assert "The file selected must be an Excel file" in str(page_html)


### PR DESCRIPTION
Adds the changes from SMD-111: Modify existing uncaught error screen with a place holder error code

Also adds the changes from SMD-83: To show the message: "The selected file must be an Excel file when users atempt to upload a non Excel file

### Change description
_A brief description of the pull request_

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
![image](https://github.com/communitiesuk/funding-service-design-post-award-submit/assets/63752812/ac679253-c3b8-40f6-a836-eba90481c287)

<img width="194" alt="Untitled" src="https://github.com/communitiesuk/funding-service-design-post-award-submit/assets/63752812/53506910-835a-40fe-9ddb-78610dc21785">
