### PR TITLE
BAU: fix email domain

### DIFF
--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -17,7 +17,7 @@ class DevelopmentConfig(DefaultConfig):
             ("Sunderland City Council", "Worcester City Council"),
             ("Sunderland City Centre", "Blackfriars - Northern City Centre", "Worcester"),
         ),
-        "levellingup.gov.uk": (
+        "communities.gov.uk": (
             ("Sunderland City Council", "Worcester City Council"),
             ("Sunderland City Centre", "Blackfriars - Northern City Centre", "Worcester"),
         ),


### PR DESCRIPTION
### Change description
Email domain for DLUHC users is actually communities.gov.uk in AD.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Should be able to authenticate locally if you have a communities/levellingup email.


### Screenshots of UI changes (if applicable)
