### PR TITLE
BAU: make email lookup case insensitive

### DIFF
--- a/app/main/authorisation.py
+++ b/app/main/authorisation.py
@@ -35,5 +35,5 @@ def get_local_authority_and_place_names(
     email_mapping = current_app.config["EMAIL_TO_LA_AND_PLACE_NAMES"]
     email_domain = user_email.split("@")[1]
     # if the domain is not present in the lookup, we will check with the whole e-mail
-    la_and_place_names = email_mapping.get(email_domain) or email_mapping.get(user_email, (None, None))
+    la_and_place_names = email_mapping.get(email_domain.lower()) or email_mapping.get(user_email.lower(), (None, None))
     return la_and_place_names

--- a/tests/test_authorisation.py
+++ b/tests/test_authorisation.py
@@ -39,6 +39,8 @@ def test_get_local_authority_place_names(flask_test_client):
         domain_mapping_4 = get_local_authority_and_place_names("user@cumberland.gov.uk")
         # tests mapping the whole email address
         email_mapping = get_local_authority_and_place_names("contractor@contractor.com")
+        # test mapping of case-insensitive e-mail
+        case_insensitive_mapping = get_local_authority_and_place_names("Contractor@contractor.com")
         # no mapping exists
         no_mapping = get_local_authority_and_place_names("user@wmadeup.gov.uk")
 
@@ -59,4 +61,5 @@ def test_get_local_authority_place_names(flask_test_client):
         ("Workington", "Cleator Moor", "Millom", "Carlisle", "Carlisle City Centre", "Maryport Town Centre"),
     )
     assert email_mapping == (("Amber Valley Borough Council",), ("Heanor",))
+    assert case_insensitive_mapping == (("Amber Valley Borough Council",), ("Heanor",))
     assert no_mapping == (None, None)


### PR DESCRIPTION
Whilst domain resolution is case-insensitive, our e-mail mappings were not. All e-mails now default to lower-case. 

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
