### PR TITLE
SMD-173: enforce role membership

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -21,7 +21,7 @@ def index():
 
 
 @bp.route("/upload", methods=["GET", "POST"])
-@login_required(return_app=SupportedApp.POST_AWARD_SUBMIT, roles_required=["TF_MONITORING_RETURN_SUBMITTER"])
+@login_required(return_app=SupportedApp.POST_AWARD_SUBMIT, roles_required=[Config.TF_SUBMITTER_ROLE])
 def upload():
     local_authorities, place_names = check_authorised()
 

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -21,7 +21,7 @@ def index():
 
 
 @bp.route("/upload", methods=["GET", "POST"])
-@login_required(return_app=SupportedApp.POST_AWARD_SUBMIT)
+@login_required(return_app=SupportedApp.POST_AWARD_SUBMIT, roles_required=["TF_MONITORING_RETURN_SUBMITTER"])
 def upload():
     local_authorities, place_names = check_authorised()
 

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -41,3 +41,5 @@ class DefaultConfig(object):
     ADDITIONAL_EMAIL_LOOKUPS = ast.literal_eval(os.getenv("ADDITIONAL_EMAIL_LOOKUPS", "{}"))
     if not isinstance(ADDITIONAL_EMAIL_LOOKUPS, dict):
         raise TypeError("ADDITIONAL_EMAIL_LOOKUPS must be a dictionary")
+
+    TF_SUBMITTER_ROLE = "TF_MONITORING_RETURN_SUBMITTER"

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -21,4 +21,8 @@ class DevelopmentConfig(DefaultConfig):
             ("Sunderland City Council", "Worcester City Council"),
             ("Sunderland City Centre", "Blackfriars - Northern City Centre", "Worcester"),
         ),
+        "test.communities.gov.uk": (
+            ("Sunderland City Council", "Worcester City Council"),
+            ("Sunderland City Centre", "Blackfriars - Northern City Centre", "Worcester"),
+        ),
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,11 @@ def mocked_auth(mocker):
     # mock authorised user
     mocker.patch(
         "fsd_utils.authentication.decorators._check_access_token",
-        return_value={"accountId": "test-user", "roles": [], "email": "user@wigan.gov.uk"},
+        return_value={
+            "accountId": "test-user",
+            "roles": ["TF_MONITORING_RETURN_SUBMITTER"],
+            "email": "user@wigan.gov.uk",
+        },
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from werkzeug.datastructures import FileStorage
 
 import config
 from app import create_app
+from config import Config
 from config.envs.unit_test import UnitTestConfig
 
 
@@ -14,7 +15,7 @@ def mocked_auth(mocker):
         "fsd_utils.authentication.decorators._check_access_token",
         return_value={
             "accountId": "test-user",
-            "roles": ["TF_MONITORING_RETURN_SUBMITTER"],
+            "roles": [Config.TF_SUBMITTER_ROLE],
             "email": "user@wigan.gov.uk",
         },
     )

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -148,12 +148,22 @@ def test_unauthenticated_upload(unauthenticated_flask_test_client):
     assert b"Sign in" in response.data
 
 
+def test_upload_without_role(unauthenticated_flask_test_client):
+    response = unauthenticated_flask_test_client.get("/")
+    assert response.status_code == 200
+    assert b"Sign in" in response.data
+
+
 def test_unauthorised_user(flask_test_client, mocker):
     """Tests scenario for an authenticated user that is unauthorized to submit."""
     # mock unauthorised user
     mocker.patch(
         "fsd_utils.authentication.decorators._check_access_token",
-        return_value={"accountId": "test-user", "roles": [], "email": "madeup@madeup.gov.uk"},
+        return_value={
+            "accountId": "test-user",
+            "roles": ["TF_MONITORING_RETURN_SUBMITTER"],
+            "email": "madeup@madeup.gov.uk",
+        },
     )
 
     response = flask_test_client.get("/upload")

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -161,7 +161,7 @@ def test_unauthorised_user(flask_test_client, mocker):
         "fsd_utils.authentication.decorators._check_access_token",
         return_value={
             "accountId": "test-user",
-            "roles": ["TF_MONITORING_RETURN_SUBMITTER"],
+            "roles": [Config.TF_SUBMITTER_ROLE],
             "email": "madeup@madeup.gov.uk",
         },
     )

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -148,7 +148,7 @@ def test_unauthenticated_upload(unauthenticated_flask_test_client):
     assert b"Sign in" in response.data
 
 
-def test_upload_without_role(unauthenticated_flask_test_client):
+def test_not_signed_in(unauthenticated_flask_test_client):
     response = unauthenticated_flask_test_client.get("/")
     assert response.status_code == 200
     assert b"Sign in" in response.data
@@ -169,6 +169,23 @@ def test_unauthorised_user(flask_test_client, mocker):
     response = flask_test_client.get("/upload")
     assert response.status_code == 401
     assert b"Sorry, you don't currently have permission to access this service" in response.data
+
+
+def test_user_without_role_cannot_access_upload(flask_test_client, mocker):
+    """Tests scenario for an authenticated user that is does not have the required role."""
+    # mock user without role
+    mocker.patch(
+        "fsd_utils.authentication.decorators._check_access_token",
+        return_value={
+            "accountId": "test-user",
+            "roles": [],
+            "email": "user@wigan.gov.uk",
+        },
+    )
+
+    response = flask_test_client.get("/upload")
+    assert response.status_code == 302
+    assert response.location == "authenticator/service/user?roles_required=TF_MONITORING_RETURN_SUBMITTER"
 
 
 def test_future_deadline_view(flask_test_client):


### PR DESCRIPTION
### Change description
Enforce user role membership to access upload route
- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
* In docker runner: user should not be able to access upload route unless they are given the role. Ensure you have latest versions of authenticator and account-store for this to work
* I can add people to the role to test being able to access once role is added
 
### Screenshots of UI changes (if applicable)
<img width="1013" alt="Screenshot 2023-10-13 at 15 59 44" src="https://github.com/communitiesuk/funding-service-design-post-award-submit/assets/1764158/733bae33-0cfd-48bb-b923-37ad5196f597">
