### PR TITLE
[BAU] remove duplicate wrapper in upload template

### DIFF
--- a/app/templates/main/upload.html
+++ b/app/templates/main/upload.html
@@ -14,113 +14,109 @@
 {% block content %}
 
     <main id="main-content" role="main">
-        <section class="govuk-main-wrapper">
-            <div class="govuk-width-container">
 
-                {% if not validation_errors %}
+        {% if not validation_errors %}
 
-                    {% set notificationHTML %}
-                        {% if days_to_deadline == 0 %}
-                            <p class="govuk-notification-banner__heading">Your data return is due today.</p>
-                        {% elif days_to_deadline == 1 %}
-                            <p class="govuk-notification-banner__heading">Your data return is due tomorrow.</p>
-                        {% elif days_to_deadline > 0 %}
-                            <p class="govuk-notification-banner__heading">Your data return is due in {{ days_to_deadline }} days.</p>
-                        {% else %}
-                                <p class="govuk-notification-banner__heading">Your data return is {{ days_to_deadline|abs }} days late.</p>
-                        {% endif %}
-                        <p class="govuk-notification-banner__heading">Submit your return as soon as possible to avoid delays in your funding.</p>
-                    {% endset %}
-
-                    {# override default blue banner with red for overdue deadlines #}
-                    {% if days_to_deadline < 0 %}
-                        {% set notificationClass %} {{ "overdue-notification-banner" }} {% endset %}
-                    {% endif %}
-
-                    {{ govukNotificationBanner ({
-                        "html": notificationHTML,
-                        "classes": notificationClass
-                    }) }}
-
-                    {% set localAuthorities %} {{ ", ".join(local_authorities) if local_authorities|length > 1 else local_authorities[0] }} {% endset %}
-
-                    <h1 class="govuk-heading-l">Submit monitoring and evaluation data</h1>
-
-                    {{ govukTable({
-                        "firstCellIsHeader": true,
-                        "head": [
-                          {
-                            "text": ""
-                          },
-                          {
-                            "text": ""
-                          }
-                        ],
-                        "rows": [
-                          [
-                            {
-                              "text": "Fund"
-                            },
-                            {
-                              "html": fund
-                            }
-                          ],
-                          [
-                            {
-                              "text": "Local authority"
-                            },
-                            {
-                              "text": localAuthorities
-                            }
-                          ],
-                          [
-                            {
-                              "text": "Reporting period"
-                            },
-                            {
-                              "text": reporting_period
-                            }
-                          ]
-                        ]
-                    }) }}
-
+            {% set notificationHTML %}
+                {% if days_to_deadline == 0 %}
+                    <p class="govuk-notification-banner__heading">Your data return is due today.</p>
+                {% elif days_to_deadline == 1 %}
+                    <p class="govuk-notification-banner__heading">Your data return is due tomorrow.</p>
+                {% elif days_to_deadline > 0 %}
+                    <p class="govuk-notification-banner__heading">Your data return is due in {{ days_to_deadline }} days.</p>
                 {% else %}
-                    <h2 class="govuk-heading-m">There are errors in your return</h2>
-                    <p class="govuk-body">The following errors have been found in your return.</p>
-                    {{ errorTable(validation_errors) }}
-                    <h2 class="govuk-heading-m">Errors fixed?</h2>
-                    <h3 class="govuk-heading-s">Re-upload your data return</h3>
+                        <p class="govuk-notification-banner__heading">Your data return is {{ days_to_deadline|abs }} days late.</p>
                 {% endif %}
+                <p class="govuk-notification-banner__heading">Submit your return as soon as possible to avoid delays in your funding.</p>
+            {% endset %}
 
-                <div class="upload-data-container govuk-!-margin-top-5">
-                    <form method="post" action="{{ url_for('main.upload') }}" enctype="multipart/form-data">
-                        {% if not pre_error %}
-                            <h2 class="govuk-heading-m">Upload your data return</h2>
+            {# override default blue banner with red for overdue deadlines #}
+            {% if days_to_deadline < 0 %}
+                {% set notificationClass %} {{ "overdue-notification-banner" }} {% endset %}
+            {% endif %}
 
-                            {{ govukFileUpload({'id': 'ingest_spreadsheet',
-                             "hint": {"text": ""},
-                             "label": {"text": ""},
-                             'name': 'ingest_spreadsheet'}) }}
-                        {% else %}
-                             <h2 class="govuk-heading-m">Upload your data return</h2>
+            {{ govukNotificationBanner ({
+                "html": notificationHTML,
+                "classes": notificationClass
+            }) }}
 
-                            {{ govukFileUpload({'id': 'ingest_spreadsheet',
-                             "hint": {"text": "Upload an Excel file"},
-                             "label": {"text": ""},
-                             "errorMessage": {"text": pre_error[0]},
-                             'name': 'ingest_spreadsheet'}) }}
-                        {% endif %}
-                        <p class="govuk-body">When you upload your return, we’ll check it for missing data and formatting errors.</p>
+            {% set localAuthorities %} {{ ", ".join(local_authorities) if local_authorities|length > 1 else local_authorities[0] }} {% endset %}
 
-                        {{ govukButton({"element": "button",
-                        "text": "Upload and check for errors",
-                        "attributes": {
-                            "aria-controls": "example-id",
-                            "data-tracking-dimension": 123} }) }}
-                    </form>
-                </div>
-            </div>
-        </section>
+            <h1 class="govuk-heading-l">Submit monitoring and evaluation data</h1>
+
+            {{ govukTable({
+                "firstCellIsHeader": true,
+                "head": [
+                  {
+                    "text": ""
+                  },
+                  {
+                    "text": ""
+                  }
+                ],
+                "rows": [
+                  [
+                    {
+                      "text": "Fund"
+                    },
+                    {
+                      "html": fund
+                    }
+                  ],
+                  [
+                    {
+                      "text": "Local authority"
+                    },
+                    {
+                      "text": localAuthorities
+                    }
+                  ],
+                  [
+                    {
+                      "text": "Reporting period"
+                    },
+                    {
+                      "text": reporting_period
+                    }
+                  ]
+                ]
+            }) }}
+
+        {% else %}
+            <h2 class="govuk-heading-m">There are errors in your return</h2>
+            <p class="govuk-body">The following errors have been found in your return.</p>
+            {{ errorTable(validation_errors) }}
+            <h2 class="govuk-heading-m">Errors fixed?</h2>
+            <h3 class="govuk-heading-s">Re-upload your data return</h3>
+        {% endif %}
+
+        <div class="upload-data-container govuk-!-margin-top-5">
+            <form method="post" action="{{ url_for('main.upload') }}" enctype="multipart/form-data">
+                {% if not pre_error %}
+                    <h2 class="govuk-heading-m">Upload your data return</h2>
+
+                    {{ govukFileUpload({'id': 'ingest_spreadsheet',
+                     "hint": {"text": ""},
+                     "label": {"text": ""},
+                     'name': 'ingest_spreadsheet'}) }}
+                {% else %}
+                     <h2 class="govuk-heading-m">Upload your data return</h2>
+
+                    {{ govukFileUpload({'id': 'ingest_spreadsheet',
+                     "hint": {"text": "Upload an Excel file"},
+                     "label": {"text": ""},
+                     "errorMessage": {"text": pre_error[0]},
+                     'name': 'ingest_spreadsheet'}) }}
+                {% endif %}
+                <p class="govuk-body">When you upload your return, we’ll check it for missing data and formatting errors.</p>
+
+                {{ govukButton({"element": "button",
+                "text": "Upload and check for errors",
+                "attributes": {
+                    "aria-controls": "example-id",
+                    "data-tracking-dimension": 123} }) }}
+            </form>
+        </div>
     </main>
 
 {% endblock content %}


### PR DESCRIPTION
Fixes the width of the upload page 

### Change description
- removes two duplicate tags that wrap upload template content. These tags were already produced by a base template component

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)

Old width:
![image](https://github.com/communitiesuk/funding-service-design-post-award-submit/assets/22678716/78df1cd8-e603-4c7f-a664-3e18b64bcd98)

New width:
![image](https://github.com/communitiesuk/funding-service-design-post-award-submit/assets/22678716/cde3dc53-6768-4db0-aadf-2c80a2a86443)

Figma width:
![image](https://github.com/communitiesuk/funding-service-design-post-award-submit/assets/22678716/534b79cc-726d-442e-9986-d231f7c3040c)
