### PR TITLE
SMD-276: init logging from utils library

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,6 +5,7 @@ from flask_assets import Bundle, Environment
 from fsd_utils import init_sentry
 from fsd_utils.healthchecks.checkers import FlaskRunningChecker
 from fsd_utils.healthchecks.healthcheck import Healthcheck
+from fsd_utils.logging import logging
 from jinja2 import ChoiceLoader, PackageLoader, PrefixLoader
 
 from app.const import EMAIL_DOMAIN_TO_LA_AND_PLACE_NAMES
@@ -51,7 +52,7 @@ def create_app(config_class=Config):
     # instantiate email to LA and place mapping used for authorizing submissions
     app.config["EMAIL_TO_LA_AND_PLACE_NAMES"] = copy(EMAIL_DOMAIN_TO_LA_AND_PLACE_NAMES)
     app.config["EMAIL_TO_LA_AND_PLACE_NAMES"].update(app.config.get("ADDITIONAL_EMAIL_LOOKUPS", {}))
-
+    logging.init_app(app)
     return app
 
 

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -1,5 +1,6 @@
 import ast
 import base64
+import logging
 import os
 from pathlib import Path
 
@@ -51,3 +52,4 @@ class DefaultConfig(object):
     CONFIRMATION_EMAIL_TEMPLATE_ID = os.environ.get(
         "CONFIRMATION_EMAIL_TEMPLATE_ID", "d3bf23d3-9798-4b6d-a75b-5430cf60b31b"
     )
+    FSD_LOG_LEVEL = os.getenv("FSD_LOG_LEVEL", logging.INFO)

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -4,7 +4,7 @@ import logging
 import os
 from pathlib import Path
 
-from fsd_utils import configclass
+from fsd_utils import CommonConfig, configclass
 
 # flake8: noqa
 
@@ -12,6 +12,7 @@ from fsd_utils import configclass
 @configclass
 class DefaultConfig(object):
     FLASK_ROOT = str(Path(__file__).parent.parent.parent)
+    FLASK_ENV = CommonConfig.FLASK_ENV
 
     CONTACT_EMAIL = os.environ.get("CONTACT_EMAIL", "fsd.support@levellingup.gov.uk")
     CONTACT_PHONE = os.environ.get("CONTACT_PHONE", "12345678910")


### PR DESCRIPTION
### Change description
Previously we were only getting system level logs through on AWS as we hadn't initialised the utils logging library.


- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Logs should come through in JSON format if the app is run in non-development environments

### Screenshots of UI changes (if applicable)
