### PR TITLE
SMD-318: Bump NGINX max body size

### DIFF
--- a/copilot/submit/manifest.yml
+++ b/copilot/submit/manifest.yml
@@ -59,6 +59,7 @@ environments:
           location: xscys/nginx-sidecar-basic-auth
         variables:
           FORWARD_PORT: 8080
+          CLIENT_MAX_BODY_SIZE: 10m
         secrets:
           BASIC_AUTH_USERNAME: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_USERNAME
           BASIC_AUTH_PASSWORD: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_PASSWORD


### PR DESCRIPTION
### Change description

Bump NGINX max body size so uploads are not curtailed on the NGINX side. Should prevent 413 errors on large file uploads on the pre-prod environments

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Should not fail with 413 when files over 1mb are uploaded


### Screenshots of UI changes (if applicable)
