### PR TITLE
add service desk URL to env vars

### DIFF
--- a/app/templates/main/help-links.html
+++ b/app/templates/main/help-links.html
@@ -2,8 +2,8 @@
 
     <div>
       <h3 class="govuk-heading-s">Service Desk</h3>
-        <p class="govuk-body"><a href="#" class="govuk-link">Submit a request for help</a> <br>
-            We aim to respond within 1 to 2 working days</p>
+        <p class="govuk-body"><a href="{{ config['SERVICE_DESK_URL'] }}" class="govuk-link">Submit a request for help</a>
+            <br> We aim to respond within 1 to 2 working days</p>
         <h3 class="govuk-heading-s">Email</h3>
         <p class="govuk-body"><a href="mailto:{{ config['CONTACT_EMAIL'] }}">{{ config['CONTACT_EMAIL'] }}</a> <br>
             We aim to respond within 1 to 2 working days

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -21,6 +21,9 @@ class DefaultConfig(object):
         "DEPARTMENT_URL",
         "https://www.gov.uk/government/organisations/department-for-levelling-up-housing-and-communities",
     )
+    SERVICE_DESK_URL = os.environ.get(
+        "SERVICE_DESK_URL", "https://dluhcdigital.atlassian.net/servicedesk/customer/portal/5/group/10/create/172"
+    )
     SERVICE_NAME = os.environ.get("SERVICE_NAME", "Submit monitoring and evaluation data")
     SERVICE_PHASE = os.environ.get("SERVICE_PHASE", "BETA")
     SERVICE_URL = os.environ.get("SERVICE_URL", "dev-service-url")


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/jira/software/c/projects/SMD/boards/140?quickFilter=815&selectedIssue=SMD-253

Adds a link to the helpdesk URL, added to help-links.html so users can access it either from the dropdown or after successfully submitting their return.

The link should be clickable from the front end, and can be changed in default.py.
