### PR TITLE
BAU: concurrency should be per environment not global

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,6 @@
 name: push to AWS
 run-name: Deploy branch ${{ github.ref_name }} to ${{ inputs.environment || 'test' }} (${{ format('SHA:{0}', github.sha) }})
-concurrency: deploy
+concurrency: deploy-${{ inputs.environment || 'test' }}
 on:
   push:
     branches:


### PR DESCRIPTION
_Add ticket reference to Pull Request title: e.g. 'FS-123: Add content', if there is no ticket prefix with BAU_


### Change description
Previously concurrency was across all deploys, concurrency should be per environment not global

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Should not concurrency lock against other environment deployment

### Screenshots of UI changes (if applicable)
