### PR TITLE
add additional local authorites for round 4

### DIFF
--- a/app/const.py
+++ b/app/const.py
@@ -40,6 +40,10 @@ EMAIL_DOMAIN_TO_LA_AND_PLACE_NAMES = {
         ("Cumberland Council",),
         ("Workington", "Cleator Moor", "Millom", "Carlisle", "Carlisle City Centre", "Maryport Town Centre"),
     ),
+    "carlisle.gov.uk": (
+        ("Cumberland Council",),
+        ("Carlisle City Centre",),
+    ),
     "darlington.gov.uk": (("Darlington Borough Council",), ("Darlington",)),
     "derby.gov.uk": (("Derby City",), ("Derby City Centre, St Peters Cross",)),
     "doncaster.gov.uk": (
@@ -156,6 +160,7 @@ EMAIL_DOMAIN_TO_LA_AND_PLACE_NAMES = {
             "Commercial Road",
         ),
     ),
+    "portsmouthcc.gov.uk": (("Portsmouth City Council",), ("Fratton",)),
     "preston.gov.uk": (("Preston City Council",), ("Preston",)),
     "redcar-cleveland.gov.uk": (
         ("Redcar & Cleveland Borough Council",),
@@ -177,6 +182,7 @@ EMAIL_DOMAIN_TO_LA_AND_PLACE_NAMES = {
     "southglos.gov.uk": (("South Gloucestershire Council",), ("Kingswood",)),
     "southkesteven.gov.uk": (("South Kesteven District Council",), ("Grantham",)),
     "southribble.gov.uk": (("South Ribble Borough Council",), ("Leyland",)),
+    "chorley.gov.uk": (("South Ribble Borough Council",), ("Leyland",)),
     "southtyneside.gov.uk": (("South Tyneside Council",), ("South Shields",)),
     "southwark.gov.uk": (("London Borough of Southwark",), ("Old Kent Road",)),
     "staffordbc.gov.uk": (("Stafford Borough Council",), ("Stafford",)),
@@ -209,5 +215,6 @@ EMAIL_DOMAIN_TO_LA_AND_PLACE_NAMES = {
     "bcpcouncil.gov.uk": (("Bournemouth, Christchurch and Poole Council",), ("Bournemouth",)),
     "eastsuffolk.gov.uk": (("East Suffolk Council",), ("Lowestoft",)),
     "northnorthants.gov.uk": (("North Northamptonshire Council",), ("Corby",)),
+    "corby.gov.uk": (("North Northamptonshire Council",), ("Corby",)),
     "westnorthants.gov.uk": (("West Northamptonshire Council",), ("Northampton",)),
 }


### PR DESCRIPTION
Added 4 new local authoritiy domains to our mapping that were sent over by towns fund, that we did not have already.

carlisle
portsmouthcc
chorley
corby

### Change description
_A brief description of the pull request_

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
