### PR TITLE
Feature/smd 346/logged out content

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -11,22 +11,23 @@ from app.main.notify import send_confirmation_emails
 from app.utils import calculate_days_to_deadline, is_load_enabled
 from config import Config
 
-logout_url = render_template("login.html")
-
 
 @bp.route("/", methods=["GET"])
 @login_requested
 def index():
     if not g.is_authenticated:
-        return render_template("login.html")
+        return redirect(url_for("main.login"))
     else:
         return redirect(url_for("main.upload"))
 
 
+@bp.route("/login", methods=["GET"])
+def login():
+    return render_template("login.html")
+
+
 @bp.route("/upload", methods=["GET", "POST"])
-@login_required(
-    logout_url=logout_url, return_app=SupportedApp.POST_AWARD_SUBMIT, roles_required=[Config.TF_SUBMITTER_ROLE]
-)
+@login_required(return_app=SupportedApp.POST_AWARD_SUBMIT, roles_required=[Config.TF_SUBMITTER_ROLE])
 def upload():
     local_authorities, place_names = check_authorised()
 

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -11,6 +11,8 @@ from app.main.notify import send_confirmation_emails
 from app.utils import calculate_days_to_deadline, is_load_enabled
 from config import Config
 
+logout_url = render_template("login.html")
+
 
 @bp.route("/", methods=["GET"])
 @login_requested
@@ -22,7 +24,9 @@ def index():
 
 
 @bp.route("/upload", methods=["GET", "POST"])
-@login_required(return_app=SupportedApp.POST_AWARD_SUBMIT, roles_required=[Config.TF_SUBMITTER_ROLE])
+@login_required(
+    logout_url=logout_url, return_app=SupportedApp.POST_AWARD_SUBMIT, roles_required=[Config.TF_SUBMITTER_ROLE]
+)
 def upload():
     local_authorities, place_names = check_authorised()
 

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -27,6 +27,7 @@ class DefaultConfig(object):
     SERVICE_URL = os.environ.get("SERVICE_URL", "dev-service-url")
     SESSION_COOKIE_SECURE = True
     DATA_STORE_API_HOST = os.environ.get("DATA_STORE_API_HOST", "http://localhost:8080")
+    LOGOUT_URL_OVERRIDE = "/login"
 
     # Funding Service Design Post Award
     FSD_USER_TOKEN_COOKIE_NAME = "fsd_user_token"

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-funding-service-design-utils==2.0.14
+funding-service-design-utils==2.0.32
 notifications-python-client==8.1.0
 cssmin==0.2.0
 jsmin==3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,9 @@ alembic==1.11.1
 babel==2.12.1
     # via flask-babel
 beautifulsoup4==4.12.2
-    # via bs4
+    # via
+    #   bs4
+    #   funding-service-design-utils
 blinker==1.6.2
     # via
     #   flask
@@ -68,7 +70,7 @@ flask-sqlalchemy==3.0.5
     #   funding-service-design-utils
 flipper-client==1.3.2
     # via funding-service-design-utils
-funding-service-design-utils==2.0.14
+funding-service-design-utils==2.0.32
     # via -r requirements.in
 govuk-frontend-jinja==2.7.0
     # via -r requirements.in

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -18,6 +18,7 @@ beautifulsoup4==4.12.2
     # via
     #   -r requirements.txt
     #   bs4
+    #   funding-service-design-utils
 black==22.12.0
     # via -r requirements_dev.in
 blinker==1.6.2
@@ -123,7 +124,7 @@ flipper-client==1.3.2
     # via
     #   -r requirements.txt
     #   funding-service-design-utils
-funding-service-design-utils==2.0.14
+funding-service-design-utils==2.0.32
     # via -r requirements.txt
 govuk-frontend-jinja==2.7.0
     # via -r requirements.txt

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -140,15 +140,22 @@ def test_upload_wrong_format(flask_test_client, example_ingest_wrong_format):
 
 
 def test_unauthenticated_upload(unauthenticated_flask_test_client):
-    response = unauthenticated_flask_test_client.get("/")
-    assert response.status_code == 200
-    assert b"Sign in" in response.data
+    response = unauthenticated_flask_test_client.get("/upload")
+    # Assert redirect to /login
+    assert response.status_code == 302
+    assert (
+        b'You should be redirected automatically to the target URL: <a href="/login">/login</a>. '
+        b"If not, click the link."
+    ) in response.data
 
 
 def test_not_signed_in(unauthenticated_flask_test_client):
     response = unauthenticated_flask_test_client.get("/")
-    assert response.status_code == 200
-    assert b"Sign in" in response.data
+    assert response.status_code == 302
+    assert (
+        b'You should be redirected automatically to the target URL: <a href="/login">/login</a>. '
+        b"If not, click the link."
+    ) in response.data
 
 
 def test_unauthorised_user(flask_test_client, mocker):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -152,6 +152,7 @@ def test_unauthenticated_upload(unauthenticated_flask_test_client):
 def test_not_signed_in(unauthenticated_flask_test_client):
     response = unauthenticated_flask_test_client.get("/")
     assert response.status_code == 302
+    assert response.location == "/login"
     assert (
         b'You should be redirected automatically to the target URL: <a href="/login">/login</a>. '
         b"If not, click the link."

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -143,20 +143,13 @@ def test_unauthenticated_upload(unauthenticated_flask_test_client):
     response = unauthenticated_flask_test_client.get("/upload")
     # Assert redirect to /login
     assert response.status_code == 302
-    assert (
-        b'You should be redirected automatically to the target URL: <a href="/login">/login</a>. '
-        b"If not, click the link."
-    ) in response.data
+    assert response.location == "/login"
 
 
 def test_not_signed_in(unauthenticated_flask_test_client):
     response = unauthenticated_flask_test_client.get("/")
     assert response.status_code == 302
     assert response.location == "/login"
-    assert (
-        b'You should be redirected automatically to the target URL: <a href="/login">/login</a>. '
-        b"If not, click the link."
-    ) in response.data
 
 
 def test_unauthorised_user(flask_test_client, mocker):


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/jira/software/c/projects/SMD/boards/140?quickFilter=815&selectedIssue=SMD-346


### Change description
Redirects the user to Submit's sign-in page at /login rather than the generic version hosted on Authenticator repo. In order for this to work, the related FSD Utils PR will need to be merged, and the relevant version number increased to reflect the changes.
