### PR TITLE
SMD-334: switch to paketo buildpack

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,17 +36,6 @@ jobs:
       - name: Git clone the repository
         uses: actions/checkout@v3
 
-      - name: Setup python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-          cache: pip   # caching pip dependencies
-
-      - name: Build static assets
-        run: |
-           pip install -r requirements_dev.txt
-           python3 build.py
-
       - name: Get current date
         id: currentdatetime
         run: echo "::set-output name=datetime::$(date +'%Y%m%d%H%M%S')"
@@ -67,6 +56,7 @@ jobs:
           yq -i '.variables.GITHUB_SHA = "${{ github.sha }}"' copilot/submit/manifest.yml
           yq -i '.http.alias = "${{ vars.ALIAS }}"' copilot/submit/manifest.yml
           yq -i '.variables.FLASK_ENV = "${{ inputs.environment || 'test' }}"' copilot/submit/manifest.yml
+          yq -i '.image.location = "ghcr.io/communitiesuk/${{ github.event.repository.name }}:${{ github.ref_name == 'main' && 'latest' || github.ref_name }}"' copilot/submit/manifest.yml
 
       - name: Copilot deploy
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,15 @@ on:
           - dev
 
 jobs:
+  paketo_build:
+    permissions:
+      packages: write
+    uses: communitiesuk/funding-service-design-workflows/.github/workflows/package.yml@main
+    with:
+      assets_required: true
+      version_to_build: $(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+      owner: ${{ github.repository_owner }}
+      application: funding-service-design-post-award-submit
   deployment:
     permissions:
       id-token: write # This is required for requesting the JWT

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn wsgi:app -c run/gunicorn/run.py --workers=3

--- a/README.md
+++ b/README.md
@@ -53,3 +53,6 @@ docker build -t communitiesuk/funding-service-design-post-award-submit .
 docker run -p 8080:8080 communitiesuk/funding-service-design-post-award-submit
 ```
 App should be available at `http://localhost:8080`
+
+## Deployment
+The app is deployed via [Github Actions](./.github/workflows/deploy.yml). On the deployment environments we use [Paketo buildpacks](https://paketo.io) rather than the local Dockerfile.

--- a/copilot/submit/manifest.yml
+++ b/copilot/submit/manifest.yml
@@ -17,8 +17,7 @@ http:
 
 # Configuration for your containers and service.
 image:
-  # Docker build arguments. For additional overrides: https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/#image-build
-  build: Dockerfile
+  location: ghcr.io/communitiesuk/funding-service-design-post-award-submit:latest
   # Port exposed through your container to route traffic to it.
   port: 8080
 

--- a/project.toml
+++ b/project.toml
@@ -1,0 +1,6 @@
+[ _ ]
+schema-version = "0.2"
+
+[[ io.buildpacks.build.env ]]
+  name = "BP_CPYTHON_VERSION"
+  value = "3.11.*" # any valid semver constraints (e.g. 3.6.7, 3.*) are acceptable


### PR DESCRIPTION
### Change description
Switches deployed environments to use [packeto buildpack](https://paketo.io/)

N.B. the local Dockerfile is retained for local development only

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Have deployed on dev environment https://github.com/communitiesuk/funding-service-design-post-award-submit/actions/runs/6772020403/job/18403679668


