### PR TITLE
[SMD-369] content and formating changes

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -21,11 +21,8 @@
     {{ govukHeader({
       'homepageUrl': url_for('main.index'),
       'serviceUrl': url_for('main.index'),
+      'serviceName':  config['SERVICE_NAME'],
       'navigation': [
-      {
-        'href': url_for('main.index'),
-        'text': config['SERVICE_NAME'],
-      },
       {
         'href': config['AUTHENTICATOR_HOST'] + "/sso/logout",
         'text': 'Sign out',
@@ -36,12 +33,7 @@
     {{ govukHeader({
       'homepageUrl': url_for('main.index'),
       'serviceUrl': url_for('main.index'),
-      'navigation': [
-      {
-        'href': url_for('main.index'),
-        'text': config['SERVICE_NAME'],
-      },
-    ]
+      'serviceName':  config['SERVICE_NAME'],
     }) }}
   {% endif %}
 {% endblock header %}

--- a/app/templates/main/errorTable.html
+++ b/app/templates/main/errorTable.html
@@ -22,10 +22,11 @@
         {% set row =
         [
         {
-            'text': error["sheet"]
+            'text': error["sheet"].capitalize(),
+            "classes": "govuk-table__header"
         },
         {
-            'text': error["section"]
+            'text': error["section"].capitalize()
         },
         {
             'text': error["cell_index"]

--- a/app/templates/main/upload.html
+++ b/app/templates/main/upload.html
@@ -53,7 +53,7 @@
 
                 <div class="upload-data-container govuk-!-margin-top-5">
                     <form method="post" action="{{ url_for('main.upload') }}" enctype="multipart/form-data">
-                        <h2 class="govuk-heading-m">Upload your data return</h2>
+                        <label class="govuk-heading-m">Upload your data return</label>
                         {% if pre_error %}
                             {{ govukFileUpload({'id': 'ingest_spreadsheet',
                              "hint": {"text": ""},
@@ -68,10 +68,10 @@
                         {% endif %}
                         <p class="govuk-body">When you upload your return, we’ll check it for missing data and formatting errors.</p>
 
-                    {{ govukButton({
-                        "element": "button",
-                        "text": "Upload and check for errors"})
-                    }}
+                        {{ govukButton({
+                            "element": "button",
+                            "text": "Upload and check for errors"})
+                        }}
 
                     </form>
                     {{ helpLinksDropdown() }}

--- a/app/templates/main/validation-errors.html
+++ b/app/templates/main/validation-errors.html
@@ -16,18 +16,16 @@
 {% block content %}
     <div class="upload-data-container govuk-!-margin-top-5">
         <form method="post" action="{{ url_for('main.upload') }}" enctype="multipart/form-data">
-            <h2 class="govuk-heading-m">There are errors in your return</h2>
+            <h1 class="govuk-heading-l">There are errors in your return</h1>
             <p class="govuk-body">Fix these errors and re-upload your return.</p>
                 {{ errorTable(validation_errors) }}
             <h2 class="govuk-heading-l">Errors fixed?</h2>
-            <h3 class="govuk-heading-m">Re-upload your data return</h3>
+            <label class="govuk-heading-m">Re-upload your data return</label>
 
             {{ govukFileUpload({'id': 'ingest_spreadsheet',
              "hint": {"text": ""},
              "label": {"text": ""},
              'name': 'ingest_spreadsheet'}) }}
-
-            <p class="govuk-body">When you upload your return, we’ll check it for missing data and formatting errors.</p>
 
             {{ govukButton({
                 "element": "button",

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -95,7 +95,7 @@ def test_upload_xlsx_validation_errors(requests_mock, example_pre_ingest_data_fi
     page_html = BeautifulSoup(response.data)
     assert response.status_code == 200
     assert "There are errors in your return" in str(page_html)
-    assert "Project Admin" in str(page_html)
+    assert "Project admin" in str(page_html)
     assert "You are missing project locations. Please enter a project location." in str(page_html)
     assert "Start date in an incorrect format. Please enter a dates in the format 'Dec-22'" in str(page_html)
 


### PR DESCRIPTION
This PR addresses several formating/ content issues raised by design here: 
https://dluhcdigital.atlassian.net/wiki/spaces/FS/pages/50561200/Design+Team+testing

in order that they appear below they are:

- Header service name too small - 15px and missing class Fix: use serviceName attribute in govukHeader
- Tab and section data displaying in title case when should be sentance case Fix: use python capitalize to force sentance case
- First column of table not tagged and formatted as table header 
- “Upload your data return” field label should be tagged as label
- “There are errors in your return” should be h1 and govuk-heading-l
- “Re-upload your data return” should be label and govuk-heading-m
- We do not redisplay this message on the validation errors screen: "When you upload your return, we’ll check it for missing data and formatting errors."

### Change description
_A brief description of the pull request_

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
![image](https://github.com/communitiesuk/funding-service-design-post-award-submit/assets/63752812/f91af5ec-ed26-4427-a029-8bc2322216d2)

![image](https://github.com/communitiesuk/funding-service-design-post-award-submit/assets/63752812/13afd6a6-a0b9-4e3d-a849-7d5eca981e18)

![image](https://github.com/communitiesuk/funding-service-design-post-award-submit/assets/63752812/586cc5bd-d73a-4c19-ac53-65a57022dcc9)
