### PR TITLE
[SMD-348] override page widths

### DIFF
--- a/app/templates/main/500.html
+++ b/app/templates/main/500.html
@@ -2,11 +2,11 @@
 
 {% block pageTitle %}Sorry, there is a problem with the service – {{ config['SERVICE_NAME'] }} – GOV.UK{% endblock pageTitle %}
 
-{% set mainClasses = "govuk-main-wrapper--l" %}
+{# Override main width to two thirds #}
+{% set mainClasses = "govuk-main-wrapper-l govuk-!-width-two-thirds" %}
 
 {% block content %}
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-width-container">
         <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
         <p class="govuk-body">Try again later.</p>
         <h2 class="govuk-heading-m">Tell us if this problem continues</h2>
@@ -16,5 +16,4 @@
         </p>
         <p class="govuk-body">Do not send your data return or any attachments to this email address.</p>
     </div>
-</div>
 {% endblock content %}

--- a/app/templates/main/login.html
+++ b/app/templates/main/login.html
@@ -7,12 +7,11 @@
 {{ super() }}
 {% endblock beforeContent %}
 
+{# Override main width to two thirds #}
+{% set mainClasses = "govuk-!-width-two-thirds" %}
+
 {% block content %}
-
-<main id="main-content" role="main">
-
-    <section class="govuk-main-wrapper">
-        <div class="govuk-width-container">
+    <div class="govuk-width-container">
         <h1 class="govuk-heading-l">Sign in to submit your data</h1>
         <p class="govuk-body">Sign in using the Microsoft account for your work email address.
         </p>
@@ -29,9 +28,5 @@
         <p class="govuk-body">If you did not receive an email, you already have an account.</p>
 
         {{ helpLinksDropdown() }}
-
-        </div>
-    </section>
-</main>
-
+    </div>
 {% endblock content %}

--- a/app/templates/main/success.html
+++ b/app/templates/main/success.html
@@ -7,36 +7,33 @@
 {{ super() }}
 {% endblock beforeContent %}
 
+{# Override main width to two thirds #}
+{% set mainClasses = "govuk-!-width-two-thirds" %}
+
 {% block content %}
-    <main id="main-content" role="main">
-        <section class="govuk-main-wrapper">
-            <div class="govuk-width-container">
+    <div class="govuk-width-container">
+        <div class="govuk-panel govuk-panel--confirmation">
+            <h1 class="govuk-heading-l success-text"> No errors found</h1>
+              <p class="govuk-!-font-size-48 govuk-!-font-weight-bold">
+                Return submitted
+              </p>
+              <p class="govuk-body govuk-!-font-size-24 success-text">
+                {{ file_name }}
+              </p>
+        </div>
 
-                <div class="govuk-panel govuk-panel--confirmation">
-                    <h1 class="govuk-heading-l success-text"> No errors found</h1>
-                      <p class="govuk-!-font-size-48 govuk-!-font-weight-bold">
-                        Return submitted
-                      </p>
-                      <p class="govuk-body govuk-!-font-size-24 success-text">
-                        {{ file_name }}
-                      </p>
-                </div>
+        <p class="govuk-body">We’ve sent you a confirmation email.</p>
+        <h2 class="govuk-heading-m">What happens next</h2>
+        <p class="govuk-body">We may email you to:</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>talk to you about your return</li>
+            <li>ask questions about the data you’ve submitted</li>
+        </ul>
+        <p class="govuk-body">We’ll do this using the email you’ve provided.</p>
 
-                <p class="govuk-body">We’ve sent you a confirmation email.</p>
-                <h2 class="govuk-heading-m">What happens next</h2>
-                <p class="govuk-body">We may email you to:</p>
-                <ul class="govuk-list govuk-list--bullet">
-                    <li>talk to you about your return</li>
-                    <li>ask questions about the data you’ve submitted</li>
-                </ul>
-                <p class="govuk-body">We’ll do this using the email you’ve provided.</p>
-
-                <div class="govuk-!-margin-top-7">
-                    <h2 class="govuk-heading-m">If you need help</h2>
-                    {{ helpLinks() }}
-                </div>
-
-            </div>
-        </section>
-    </main>
+        <div class="govuk-!-margin-top-7">
+            <h2 class="govuk-heading-m">If you need help</h2>
+            {{ helpLinks() }}
+        </div>
+    </div>
 {% endblock content %}

--- a/app/templates/main/upload.html
+++ b/app/templates/main/upload.html
@@ -15,68 +15,65 @@
 {{ super() }}
 {% endblock beforeContent %}
 
+{# Override main width to two thirds #}
+{% set mainClasses = "govuk-!-width-two-thirds" %}
+
 {% block content %}
-    {#    TODO remove duplicate tags   #}
-    <main id="main-content" role="main">
-        <section class="govuk-main-wrapper">
-            <div class="govuk-width-container">
+    <div class="govuk-width-container">
+        {% if pre_error %}
+            {{ errorSummary(pre_error) }}
+        {% endif %}
+
+        {% if days_to_deadline <= 7 %}
+            {% set notificationHTML %}
+                {% if days_to_deadline == 0 %}
+                    <p class="govuk-notification-banner__heading">Your data return is due today.</p>
+                {% elif days_to_deadline == 1 %}
+                    <p class="govuk-notification-banner__heading">Your data return is due tomorrow.</p>
+                {% elif days_to_deadline > 0 %}
+                    <p class="govuk-notification-banner__heading">Your data return is due in {{ days_to_deadline }} days.</p>
+                {% else %}
+                        <p class="govuk-notification-banner__heading">Your data return is {{ days_to_deadline|abs }} days late.</p>
+                {% endif %}
+                <p class="govuk-notification-banner__heading">Submit your return as soon as possible to avoid delays in your funding.</p>
+            {% endset %}
+
+            {# override default blue banner with red for overdue deadlines #}
+            {% if days_to_deadline < 0 %}
+                {% set notificationClass %} {{ "overdue-notification-banner" }} {% endset %}
+            {% endif %}
+
+            {{ govukNotificationBanner ({
+                "html": notificationHTML,
+                "classes": notificationClass
+            }) }}
+        {% endif %}
+
+        {{ uploadTable(local_authorities, fund, reporting_period) }}
+
+        <div class="upload-data-container govuk-!-margin-top-5">
+            <form method="post" action="{{ url_for('main.upload') }}" enctype="multipart/form-data">
+                <label class="govuk-heading-m">Upload your data return</label>
                 {% if pre_error %}
-                    {{ errorSummary(pre_error) }}
+                    {{ govukFileUpload({'id': 'ingest_spreadsheet',
+                     "hint": {"text": ""},
+                     "label": {"text": ""},
+                     "errorMessage": {"html": errorMessage(pre_error)},
+                     'name': 'ingest_spreadsheet'}) }}
+                {% else %}
+                    {{ govukFileUpload({'id': 'ingest_spreadsheet',
+                     "hint": {"text": ""},
+                     "label": {"text": ""},
+                     'name': 'ingest_spreadsheet'}) }}
                 {% endif %}
+                <p class="govuk-body">When you upload your return, we’ll check it for missing data and formatting errors.</p>
 
-                {% if days_to_deadline <= 7 %}
-                    {% set notificationHTML %}
-                        {% if days_to_deadline == 0 %}
-                            <p class="govuk-notification-banner__heading">Your data return is due today.</p>
-                        {% elif days_to_deadline == 1 %}
-                            <p class="govuk-notification-banner__heading">Your data return is due tomorrow.</p>
-                        {% elif days_to_deadline > 0 %}
-                            <p class="govuk-notification-banner__heading">Your data return is due in {{ days_to_deadline }} days.</p>
-                        {% else %}
-                                <p class="govuk-notification-banner__heading">Your data return is {{ days_to_deadline|abs }} days late.</p>
-                        {% endif %}
-                        <p class="govuk-notification-banner__heading">Submit your return as soon as possible to avoid delays in your funding.</p>
-                    {% endset %}
-
-                    {# override default blue banner with red for overdue deadlines #}
-                    {% if days_to_deadline < 0 %}
-                        {% set notificationClass %} {{ "overdue-notification-banner" }} {% endset %}
-                    {% endif %}
-
-                    {{ govukNotificationBanner ({
-                        "html": notificationHTML,
-                        "classes": notificationClass
-                    }) }}
-                {% endif %}
-
-                {{ uploadTable(local_authorities, fund, reporting_period) }}
-
-                <div class="upload-data-container govuk-!-margin-top-5">
-                    <form method="post" action="{{ url_for('main.upload') }}" enctype="multipart/form-data">
-                        <label class="govuk-heading-m">Upload your data return</label>
-                        {% if pre_error %}
-                            {{ govukFileUpload({'id': 'ingest_spreadsheet',
-                             "hint": {"text": ""},
-                             "label": {"text": ""},
-                             "errorMessage": {"html": errorMessage(pre_error)},
-                             'name': 'ingest_spreadsheet'}) }}
-                        {% else %}
-                            {{ govukFileUpload({'id': 'ingest_spreadsheet',
-                             "hint": {"text": ""},
-                             "label": {"text": ""},
-                             'name': 'ingest_spreadsheet'}) }}
-                        {% endif %}
-                        <p class="govuk-body">When you upload your return, we’ll check it for missing data and formatting errors.</p>
-
-                        {{ govukButton({
-                            "element": "button",
-                            "text": "Upload and check for errors"})
-                        }}
-
-                    </form>
-                    {{ helpLinksDropdown() }}
-                </div>
-            </div>
-        </section>
-    </main>
+                {{ govukButton({
+                    "element": "button",
+                    "text": "Upload and check for errors"})
+                }}
+            </form>
+            {{ helpLinksDropdown() }}
+        </div>
+    </div>
 {% endblock content %}

--- a/app/templates/main/validation-errors.html
+++ b/app/templates/main/validation-errors.html
@@ -13,6 +13,9 @@
 {{ super() }}
 {% endblock beforeContent %}
 
+{# Override main width to full #}
+{% set mainClasses = "govuk-!-width-full" %}
+
 {% block content %}
     <div class="upload-data-container govuk-!-margin-top-5">
         <form method="post" action="{{ url_for('main.upload') }}" enctype="multipart/form-data">


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/SMD-348

### Change description
- overrides the width of the error page to full
- overrides the width of the upload, login, success and 500 pages to two thirds

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
