### PR TITLE
format validation errors for logging and add flag to config

### DIFF
--- a/app/const.py
+++ b/app/const.py
@@ -1,5 +1,10 @@
 from enum import StrEnum
 
+PRE_VALIDATION_ERROR_LOG = "Pre-validation error: {error}"
+PRE_VALIDATION_LOG = "Pre-validation error(s) found during upload"
+VALIDATION_ERROR_LOG = "Validation error: {error}"
+VALIDATION_LOG = "Validation error(s) found during upload"
+
 
 class MIMETYPE(StrEnum):
     XLSX = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -45,7 +45,11 @@ def upload():
         file_format = excel_file.content_type
         if file_format != MIMETYPE.XLSX:
             error = ["The selected file must be an Excel file."]
-            current_app.logger.info("Incorrect file format uploaded")
+            current_app.logger.info(
+                f"Pre-validation error: {error}"
+                if Config.ENABLE_VALIDATION_LOGGING
+                else "Pre-validation error(s) found during upload"
+            )
             return render_template(
                 "upload.html",
                 pre_error=error,
@@ -70,7 +74,7 @@ def upload():
                 for pre_err in pre_errors:
                     current_app.logger.info(f"Pre-validation error: {pre_err}")
             else:
-                "Pre-validation error(s) found during upload"
+                current_app.logger.info("Pre-validation error(s) found during upload")
 
             return render_template(
                 "upload.html",
@@ -83,9 +87,9 @@ def upload():
         else:
             if Config.ENABLE_VALIDATION_LOGGING:
                 for validation_err in validation_errors:
-                    current_app.logger.info(f"Pre-validation error: {validation_err}")
+                    current_app.logger.info(f"Validation error: {validation_err}")
             else:
-                "Validation error(s) found during upload"
+                current_app.logger.info("Validation error(s) found during upload")
 
             return render_template(
                 "validation-errors.html",

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -45,7 +45,8 @@ def upload():
         file_format = excel_file.content_type
         if file_format != MIMETYPE.XLSX:
             error = ["The selected file must be an Excel file."]
-            current_app.logger.info("Incorrect file format uploaded")
+            if Config.ENABLE_VALIDATION_LOGGING:
+                current_app.logger.info("Incorrect file format uploaded")
             return render_template(
                 "upload.html",
                 pre_error=error,
@@ -66,7 +67,8 @@ def upload():
             current_app.logger.info(f"Upload successful: {metadata}")
             return render_template("success.html", file_name=excel_file.filename)
         elif pre_errors:
-            current_app.logger.info("Pre-validation errors found during upload")
+            if Config.ENABLE_VALIDATION_LOGGING:
+                current_app.logger.info(f"Pre-validation error(s) found during upload: {pre_errors}")
 
             return render_template(
                 "upload.html",
@@ -77,8 +79,12 @@ def upload():
                 fund=Config.FUND_NAME,
             )
         else:
-            current_app.logger.info("Validation errors found during upload")
-
+            combined_error = {
+                key: [error[key] for error in validation_errors]
+                for key in ["cell_index", "description", "section", "sheet"]
+            }
+            if Config.ENABLE_VALIDATION_LOGGING:
+                current_app.logger.info(f"Validation errors found during upload: {combined_error}")
             return render_template(
                 "validation-errors.html",
                 validation_errors=validation_errors,

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -45,8 +45,7 @@ def upload():
         file_format = excel_file.content_type
         if file_format != MIMETYPE.XLSX:
             error = ["The selected file must be an Excel file."]
-            if Config.ENABLE_VALIDATION_LOGGING:
-                current_app.logger.info("Incorrect file format uploaded")
+            current_app.logger.info("Incorrect file format uploaded")
             return render_template(
                 "upload.html",
                 pre_error=error,
@@ -69,6 +68,8 @@ def upload():
         elif pre_errors:
             if Config.ENABLE_VALIDATION_LOGGING:
                 current_app.logger.info(f"Pre-validation error(s) found during upload: {pre_errors}")
+            else:
+                current_app.logger.info("Pre-validation error(s) found during upload")
 
             return render_template(
                 "upload.html",
@@ -79,12 +80,10 @@ def upload():
                 fund=Config.FUND_NAME,
             )
         else:
-            combined_error = {
-                key: [error[key] for error in validation_errors]
-                for key in ["cell_index", "description", "section", "sheet"]
-            }
             if Config.ENABLE_VALIDATION_LOGGING:
-                current_app.logger.info(f"Validation errors found during upload: {combined_error}")
+                current_app.logger.info(f"Validation errors found during upload: {validation_errors}")
+            else:
+                current_app.logger.info("Validation errors found during upload")
             return render_template(
                 "validation-errors.html",
                 validation_errors=validation_errors,

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -3,7 +3,13 @@ from fsd_utils.authentication.config import SupportedApp
 from fsd_utils.authentication.decorators import login_requested, login_required
 from werkzeug.exceptions import HTTPException
 
-from app.const import MIMETYPE
+from app.const import (
+    MIMETYPE,
+    PRE_VALIDATION_ERROR_LOG,
+    PRE_VALIDATION_LOG,
+    VALIDATION_ERROR_LOG,
+    VALIDATION_LOG,
+)
 from app.main import bp
 from app.main.authorisation import check_authorised
 from app.main.data_requests import post_ingest
@@ -46,9 +52,7 @@ def upload():
         if file_format != MIMETYPE.XLSX:
             error = ["The selected file must be an Excel file."]
             current_app.logger.info(
-                f"Pre-validation error: {error}"
-                if Config.ENABLE_VALIDATION_LOGGING
-                else "Pre-validation error(s) found during upload"
+                PRE_VALIDATION_ERROR_LOG.format(error=error) if Config.ENABLE_VALIDATION_LOGGING else PRE_VALIDATION_LOG
             )
             return render_template(
                 "upload.html",
@@ -72,9 +76,9 @@ def upload():
         elif pre_errors:
             if Config.ENABLE_VALIDATION_LOGGING:
                 for pre_err in pre_errors:
-                    current_app.logger.info(f"Pre-validation error: {pre_err}")
+                    current_app.logger.info(PRE_VALIDATION_ERROR_LOG.format(error=pre_err))
             else:
-                current_app.logger.info("Pre-validation error(s) found during upload")
+                current_app.logger.info(PRE_VALIDATION_LOG)
 
             return render_template(
                 "upload.html",
@@ -87,9 +91,9 @@ def upload():
         else:
             if Config.ENABLE_VALIDATION_LOGGING:
                 for validation_err in validation_errors:
-                    current_app.logger.info(f"Validation error: {validation_err}")
+                    current_app.logger.info(VALIDATION_ERROR_LOG.format(error=validation_err))
             else:
-                current_app.logger.info("Validation error(s) found during upload")
+                current_app.logger.info(VALIDATION_LOG)
 
             return render_template(
                 "validation-errors.html",

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -67,9 +67,10 @@ def upload():
             return render_template("success.html", file_name=excel_file.filename)
         elif pre_errors:
             if Config.ENABLE_VALIDATION_LOGGING:
-                current_app.logger.info(f"Pre-validation error(s) found during upload: {pre_errors}")
+                for pre_err in pre_errors:
+                    current_app.logger.info(f"Pre-validation error: {pre_err}")
             else:
-                current_app.logger.info("Pre-validation error(s) found during upload")
+                "Pre-validation error(s) found during upload"
 
             return render_template(
                 "upload.html",
@@ -81,9 +82,11 @@ def upload():
             )
         else:
             if Config.ENABLE_VALIDATION_LOGGING:
-                current_app.logger.info(f"Validation errors found during upload: {validation_errors}")
+                for validation_err in validation_errors:
+                    current_app.logger.info(f"Pre-validation error: {validation_err}")
             else:
-                current_app.logger.info("Validation errors found during upload")
+                "Validation error(s) found during upload"
+
             return render_template(
                 "validation-errors.html",
                 validation_errors=validation_errors,

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -11,7 +11,7 @@ from fsd_utils import CommonConfig, configclass
 class DefaultConfig(object):
     FLASK_ROOT = str(Path(__file__).parent.parent.parent)
     FLASK_ENV = CommonConfig.FLASK_ENV
-    ENABLE_VALIDATION_LOGGING = True
+    ENABLE_VALIDATION_LOGGING = os.environ.get("ENABLE_VALIDATION_LOGGING", False)
 
     CONTACT_EMAIL = os.environ.get("CONTACT_EMAIL", "fsd.support@levellingup.gov.uk")
     CONTACT_PHONE = os.environ.get("CONTACT_PHONE", "12345678910")

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -11,6 +11,7 @@ from fsd_utils import CommonConfig, configclass
 class DefaultConfig(object):
     FLASK_ROOT = str(Path(__file__).parent.parent.parent)
     FLASK_ENV = CommonConfig.FLASK_ENV
+    ENABLE_VALIDATION_LOGGING = True
 
     CONTACT_EMAIL = os.environ.get("CONTACT_EMAIL", "fsd.support@levellingup.gov.uk")
     CONTACT_PHONE = os.environ.get("CONTACT_PHONE", "12345678910")

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -78,13 +78,13 @@ def test_upload_xlsx_validation_errors(requests_mock, example_pre_ingest_data_fi
                 {
                     "sheet": "Project Admin",
                     "section": "section1",
-                    "cell": "A1",
+                    "cell_index": "A1",
                     "description": "You are missing project locations. Please enter a project location.",
                 },
                 {
                     "sheet": "Tab2",
                     "section": "section2",
-                    "cell": "B2-Y2",
+                    "cell_index": "B2-Y2",
                     "description": "Start date in an incorrect format. Please enter a dates in the format 'Dec-22'",
                 },
             ],


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/jira/software/c/projects/SMD/boards/140?quickFilter=815&selectedIssue=SMD-361


### Change description
Formats and displays pre-validation/validation errors for logging. Also implements a flag which can be turned off the disable this logging. I have not included any further information as to the error type from data-store, however this can be included if others think it will be beneficial.

I have updated the outdated key names from cell to cell_index in test_upload_xlsx_validation_errors. I have checked this is the expected name in the back end also.


### How to test
The errors should be available in the Docker logs/terminal console when testing locally. The flag ENABLE_VALIDATION_LOGGING is set to True by default in config/default.py
