### PR TITLE
[BAU] nottingham city centre place name to not include a comma

### DIFF
--- a/app/const.py
+++ b/app/const.py
@@ -165,7 +165,7 @@ EMAIL_DOMAIN_TO_LA_AND_PLACE_NAMES = {
         ),
     ),
     "norwich.gov.uk": (("Norwich City Council",), ("Norwich",)),
-    "nottinghamcity.gov.uk": (("Nottingham City Council",), ("Nottingham City Centre, West End Point",)),
+    "nottinghamcity.gov.uk": (("Nottingham City Council",), ("Nottingham City Centre - West End Point",)),
     "nuneatonandbedworth.gov.uk": (
         ("Nuneaton & Bedworth Borough Council",),
         (


### PR DESCRIPTION

### Change description
- Replaces comma with a dash in nottingham city centre place name so it isn't separated into two when the request is parsed.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
