### PR TITLE
[BAU] add legacy Buckinghamshire domain to auth mapping

### DIFF
--- a/app/const.py
+++ b/app/const.py
@@ -28,6 +28,7 @@ EMAIL_DOMAIN_TO_LA_AND_PLACE_NAMES = {
     "bradford.gov.uk": (("Bradford Council",), ("Shipley", "Keighley")),
     "broxtowe.gov.uk": (("Broxtowe Borough Council",), ("Stapleford",)),
     "buckinghamshire.gov.uk": (("Buckinghamshire Council",), ("High Wycombe",)),
+    "buckscc.gov.uk": (("Buckinghamshire Council",), ("High Wycombe",)),
     "calderdale.gov.uk": (
         ("Calderdale Council",),
         ("Halifax", "Brighouse", "Todmorden", "Elland Town Centre"),


### PR DESCRIPTION
### Change description
- adds legacy Buckinghamshire domain to auth mapping

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
