### PR TITLE
Smd 383/feature/additional http errors

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -120,11 +120,17 @@ def check_file(excel_file: FileStorage) -> str | None:
 
 @bp.app_errorhandler(HTTPException)
 def http_exception(error):
+    """
+    Returns the correct page template for specified HTTP errors, and the
+    500 (generic) template for any others.
+
+    :param error: object containing attributes related to the error
+    :return: HTML template describing user-facing error, and error code
+    """
     error_templates = (401, 404, 429, 500, 503)
 
     if error.code in error_templates:
         return render_template(f"{error.code}.html"), error.code
     else:
-        if Config.ENABLE_VALIDATION_LOGGING:
-            current_app.logger.info(f"Unhandled HTTP error {error.code} found.")
-        return render_template("500.html")
+        current_app.logger.info(f"Unhandled HTTP error {error.code} found.")
+        return render_template("500.html"), error.code

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -120,4 +120,9 @@ def check_file(excel_file: FileStorage) -> str | None:
 
 @bp.app_errorhandler(HTTPException)
 def http_exception(error):
-    return render_template(f"{error.code}.html"), error.code
+    error_templates = (401, 404, 429, 500, 503)
+
+    if error.code in error_templates:
+        return render_template(f"{error.code}.html"), error.code
+    else:
+        return render_template("500.html")

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -125,4 +125,6 @@ def http_exception(error):
     if error.code in error_templates:
         return render_template(f"{error.code}.html"), error.code
     else:
+        if Config.ENABLE_VALIDATION_LOGGING:
+            current_app.logger.info(f"Unhandled HTTP error {error.code} found.")
         return render_template("500.html")

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -101,15 +101,6 @@ def test_upload_xlsx_validation_errors(requests_mock, example_pre_ingest_data_fi
     assert "You are missing project locations. Please enter a project location." in str(page_html)
     assert "Start date in an incorrect format. Please enter a dates in the format 'Dec-22'" in str(page_html)
 
-    # assert errors display correctly
-    assert '<th class="govuk-table__header" scope="col">Description</th>' in str(page_html)
-    assert '<th class="govuk-table__header" scope="col">Cell</th>' in str(page_html)
-    assert (
-        '<td class="govuk-table__cell">You are missing project locations. Please enter a project location.</td>'
-        in str(page_html)
-    )
-    assert '<td class="govuk-table__cell">Section2</td>' in str(page_html)
-
 
 def test_upload_ingest_generic_bad_request(requests_mock, example_pre_ingest_data_file, flask_test_client):
     requests_mock.post(
@@ -271,3 +262,21 @@ def test_multiple_local_authorities_view(flask_test_client, mocker):
 
     assert b"Council 1, Council 2, Council 3" in response.data
     assert b"('Council 1', 'Council 2', 'Council 3')" not in response.data
+
+
+def test_known_http_error_redirect(flask_test_client):
+    # induce a known error
+    response = flask_test_client.get("/unknown-page")
+
+    # 404 template should be rendered
+    assert b"Page not found" in response.data
+    assert b"If you typed the web address, check it is correct." in response.data
+
+
+def test_http_error_unknown_redirects(flask_test_client, requests_mock):
+    # induce an unknown error
+    response = flask_test_client.post("/?g=obj_app_upfile")
+
+    # 500 template should be rendered
+    assert b"Sorry, there is a problem with the service" in response.data
+    assert b"Try again later." in response.data

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -268,15 +268,17 @@ def test_known_http_error_redirect(flask_test_client):
     # induce a known error
     response = flask_test_client.get("/unknown-page")
 
-    # 404 template should be rendered
+    assert response.status_code == 404
+    # 404.html template should be rendered
     assert b"Page not found" in response.data
     assert b"If you typed the web address, check it is correct." in response.data
 
 
-def test_http_error_unknown_redirects(flask_test_client, requests_mock):
-    # induce an unknown error
+def test_http_error_unknown_redirects(flask_test_client):
+    # induce a 405 error
     response = flask_test_client.post("/?g=obj_app_upfile")
 
-    # 500 template should be rendered
+    assert response.status_code == 405
+    # generic error template should be rendered
     assert b"Sorry, there is a problem with the service" in response.data
     assert b"Try again later." in response.data

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -80,12 +80,14 @@ def test_upload_xlsx_validation_errors(requests_mock, example_pre_ingest_data_fi
                     "section": "section1",
                     "cell_index": "A1",
                     "description": "You are missing project locations. Please enter a project location.",
+                    "error_type": "NonNullableConstraintFailure",
                 },
                 {
                     "sheet": "Tab2",
                     "section": "section2",
                     "cell_index": "B2-Y2",
                     "description": "Start date in an incorrect format. Please enter a dates in the format 'Dec-22'",
+                    "error_type": "TownsFundRoundFourValidationFailure",
                 },
             ],
         },
@@ -98,6 +100,15 @@ def test_upload_xlsx_validation_errors(requests_mock, example_pre_ingest_data_fi
     assert "Project admin" in str(page_html)
     assert "You are missing project locations. Please enter a project location." in str(page_html)
     assert "Start date in an incorrect format. Please enter a dates in the format 'Dec-22'" in str(page_html)
+
+    # assert errors display correctly
+    assert '<th class="govuk-table__header" scope="col">Description</th>' in str(page_html)
+    assert '<th class="govuk-table__header" scope="col">Cell</th>' in str(page_html)
+    assert (
+        '<td class="govuk-table__cell">You are missing project locations. Please enter a project location.</td>'
+        in str(page_html)
+    )
+    assert '<td class="govuk-table__cell">Section2</td>' in str(page_html)
 
 
 def test_upload_ingest_generic_bad_request(requests_mock, example_pre_ingest_data_file, flask_test_client):


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/jira/software/c/projects/SMD/boards/140?quickFilter=815&selectedIssue=SMD-383


Redirects previously unhandled errors (those not in the exisiting error templates) to the generic 500 error page, instead of creating an unhandled exception.
