### PR TITLE
add cannockchase to email domain mapping

### DIFF
--- a/app/const.py
+++ b/app/const.py
@@ -31,6 +31,7 @@ EMAIL_DOMAIN_TO_LA_AND_PLACE_NAMES = {
     "cheshireeast.gov.uk": (("Cheshire East Council",), ("Crewe",)),
     "cheshirewestandchester.gov.uk": (("Cheshire West and Chester Council",), ("Winsford",)),
     "chesterfield.gov.uk": (("Chesterfield Borough Council",), ("Staveley",)),
+    "cannockchasedc.gov.uk": (("Ashfield District Council",), ("Sutton in Ashfield", "Kirkby and Sutton (Ashfield)")),
     "colchester.gov.uk": (("Colchester City Council",), ("Colchester",)),
     "cornwall.gov.uk": (("Cornwall Council",), ("Truro", "Camborne", "Penzance", "St Ives")),
     "durham.gov.uk": (("Durham County Council",), ("Bishop Auckland",)),


### PR DESCRIPTION
Add Cannock chase email domain to help user who has had difficulty with microsoft authenticator access the service from a seperate account.


### Change description
_A brief description of the pull request_

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
