### PR TITLE
add mendip email domain

### DIFF
--- a/app/const.py
+++ b/app/const.py
@@ -100,6 +100,15 @@ EMAIL_DOMAIN_TO_LA_AND_PLACE_NAMES = {
     "lincoln.gov.uk": (("City of Lincoln Council",), ("Lincoln",)),
     "mansfield.gov.uk": (("Mansfield District Council",), ("Mansfield",)),
     "medway.gov.uk": (("Medway Council",), ("Chatham Town Centre",)),
+    "mendip.gov.uk": (
+        ("Somerset Council",),
+        (
+            "Yeovil",
+            "Bridgwater",
+            "Glastonbury",
+            "Taunton",
+        ),
+    ),
     "middlesbrough.gov.uk": (
         ("Middlesbrough Council",),
         (


### PR DESCRIPTION
Add mendip.gov.uk to the authenticated email domains with the same permissions as somerset.go.uk

As medip has recently merged into somerset


### Change description
_A brief description of the pull request_

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
