### PR TITLE
[BAU] set up logging first during app initialisation

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -20,6 +20,7 @@ def create_app(config_class=Config):
     init_sentry()
     app = Flask(__name__, static_url_path="/static")
     app.config.from_object(config_class)
+    logging.init_app(app)
     app.jinja_env.lstrip_blocks = True
     app.jinja_env.trim_blocks = True
     app.jinja_loader = ChoiceLoader(
@@ -52,7 +53,6 @@ def create_app(config_class=Config):
     email_mapping.update(Config.ADDITIONAL_EMAIL_LOOKUPS)
     app.config["AUTH_MAPPING"]: AuthMapping = build_auth_mapping(Config.FUND_NAME, email_mapping)
 
-    logging.init_app(app)
     return app
 
 


### PR DESCRIPTION
### Change description
Logging was being configured at the end of app initialisation, causing some logs to be lost.

-  set up logging first during app initialisation

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
