### PR TITLE
[BAU] convert emails to lower case when reading from a mapping

### DIFF
--- a/app/main/authorisation.py
+++ b/app/main/authorisation.py
@@ -73,7 +73,7 @@ class AuthMapping:
         """
         self._auth_class = auth_class
         # for each item in the dictionary, encapsulate the auth details values in an instance of the auth_class
-        self._mapping = {email: auth_class(*auth_details) for email, auth_details in mapping.items()}
+        self._mapping = {email.lower(): auth_class(*auth_details) for email, auth_details in mapping.items()}
 
     def get_auth(self, email: str) -> AuthBase | None:
         """Get the authorisation information associated with the given email address.

--- a/tests/test_authorisation.py
+++ b/tests/test_authorisation.py
@@ -15,6 +15,7 @@ def mock_mapping():
     mapping = {
         "wizard1@hogwarts.magic.uk": (("Hogwarts",), ("Professor Albus Dumbledore",)),
         "hogwarts.magic.uk": (("Hogwarts",), ("Harry Potter", "Ron Weasley")),
+        "wizardWITHCAPSINMAPPING@charingcross.magic.uk": (("Diagon Alley",), ("Snape",)),
     }
     return mapping
 
@@ -64,6 +65,19 @@ def test_auth_mapping_email_match_case_insensitive(mock_auth_mapping, mock_auth_
     assert isinstance(auth, mock_auth_class)
     assert auth.get_organisations() == ("Hogwarts",)
     assert auth.get_auth_dict() == {"Wizards": ("Professor Albus Dumbledore",)}
+
+
+def test_auth_mapping_email_match_case_insensitive_from_mapping(mock_auth_mapping, mock_auth_class):
+    """
+    GIVEN a valid AuthMapping object
+    WHEN an email address is passed to it that contained caps in the original mapping
+    THEN it should return the mapping for that email regardless of case
+    """
+    auth = mock_auth_mapping.get_auth("wizardwithcapsinmapping@charingcross.magic.uk")
+
+    assert isinstance(auth, mock_auth_class)
+    assert auth.get_organisations() == ("Diagon Alley",)
+    assert auth.get_auth_dict() == {"Wizards": ("Snape",)}
 
 
 def test_auth_mapping_domain_match(mock_auth_mapping, mock_auth_class):


### PR DESCRIPTION
### Change description
 - fixes an issue where mapping contained upper case emails that could never be matched
 - we now `.lower()` all emails on setting up auth

- [X] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
