### PR TITLE
add somersetwestandtaunton.gov.uk to auth mapping

### DIFF
--- a/app/const.py
+++ b/app/const.py
@@ -353,6 +353,11 @@ TOWNS_FUND_AUTH = {
         ("Yeovil", "Bridgwater", "Glastonbury", "Taunton"),
         ("Town_Deal", "Future_High_Street_Fund"),
     ),
+    "somersetwestandtaunton.gov.uk": (
+        ("Somerset Council",),
+        ("Yeovil", "Bridgwater", "Glastonbury", "Taunton"),
+        ("Town_Deal", "Future_High_Street_Fund"),
+    ),
     "southglos.gov.uk": (("South Gloucestershire Council",), ("Kingswood",), ("Town_Deal", "Future_High_Street_Fund")),
     "southkesteven.gov.uk": (
         ("South Kesteven District Council",),


### PR DESCRIPTION
Added somersetwestandtaunton.gov.uk to auth mapping so that a user can submit for the same places as somerset.gov.uk

### Change description
_A brief description of the pull request_

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
