### PR TITLE
[SMD-493] Data Validations in Towns Fund Round 4

### DIFF
--- a/scripts/log_analysis.py
+++ b/scripts/log_analysis.py
@@ -1,0 +1,56 @@
+import pandas as pd
+
+# read in log csv
+log_file = "./logs-insights.csv"  # path to logs as .csv
+logs = pd.read_csv(log_file)
+
+messages = [eval(result.strip('Message: "Validation error: ')) for result in logs["@message"]]
+messages = pd.DataFrame([result for result in messages if isinstance(result, dict)])
+
+
+# clean data
+def convert_error_type_to_reason(message):
+    error_type_to_reason = {
+        "NonNullableConstraintFailure": "Cell left empty",
+        "WrongTypeFailure": "Invalid data entered",
+        "NonUniqueCompositeKeyFailure": "Duplicate data entered",
+        "InvalidEnumValueFailure": "Invalid dropdown value entered",
+    }
+
+    if message["error_type"] in ["TownsFundRoundFourValidationFailure", "GenericFailure"]:
+        if "CDEL" in message["description"] or "RDEL" in message["description"]:
+            return "Allocated funding exceeded"
+        elif "postcode" in message["description"]:
+            return error_type_to_reason["WrongTypeFailure"]
+        elif "blank" in message["description"]:
+            return error_type_to_reason["NonNullableConstraintFailure"]
+        elif "entered your own content" in message["description"]:
+            return error_type_to_reason["InvalidEnumValueFailure"]
+        else:
+            return "Generic error"
+    else:
+        return error_type_to_reason[message["error_type"]]
+
+
+messages["reason"] = messages.apply(convert_error_type_to_reason, axis=1)
+
+# generate plots
+group_by_error = messages.groupby("reason").count()["sheet"].sort_values(ascending=False)
+print(group_by_error)
+error_pie = group_by_error.plot.pie(autopct="%1.1f%%", title="Reasons for validation errors", label="")
+fig = error_pie.get_figure()
+fig.savefig("validation_error_reasons.png", bbox_inches="tight")
+fig.show()  # flushes current fig from figure so the next one isn't rendered on top
+
+group_by_tab = messages.groupby("sheet").count()["section"].sort_values(ascending=False)
+print(group_by_tab)
+tab_pie = group_by_tab.plot.pie(autopct="%1.1f%%", title="Validation errors per spreadsheet tab", label="")
+fig = tab_pie.get_figure()
+fig.savefig("validation_errors_per_tab.png", bbox_inches="tight")
+fig.show()
+
+group_by_tab_error = messages.groupby(["sheet", "reason"]).count()["section"].unstack("reason")
+error_tab_bar = group_by_tab_error.plot.bar(title="Validation error types per spreadsheet tab", width=1)
+fig = error_tab_bar.get_figure()
+fig.savefig("validation_error_reasons_per_tab.png", bbox_inches="tight")
+fig.show()


### PR DESCRIPTION
Script for the generation of a few graphs from the round 4 logs. Mainly pushed for visibility, could be merged if we decide we would like to capture similar insights for Round 5 and beyond.

The Script:
- extracts the logs into a Pandas dataframe, 
- converts error types to humman readable reasons
- uses pd.group_by to summarize the data for plotting in the charts bellow


**R4 Example**

150 data points

group by reason:
reason
Cell left empty                   73
Allocated funding exceeded        59
Invalid data entered              11
Invalid dropdown value entered     4
Duplicate data entered             3

group by sheet
Funding Profiles      88
Project Outputs       25
Project Admin         12
Programme Progress    11
Outcomes               8
Risk Register          5
Review & Sign-Off      1

![validation_error_reasons](https://github.com/communitiesuk/funding-service-design-post-award-submit/assets/63752812/ef7ce4c4-da5f-4fb5-8bbd-6cc03d1bd992)

![validation_errors_per_tab](https://github.com/communitiesuk/funding-service-design-post-award-submit/assets/63752812/f84a145c-6a16-456d-9a48-326a9950ebb4)

![validation_error_reasons_per_tab](https://github.com/communitiesuk/funding-service-design-post-award-submit/assets/63752812/900207d4-ea14-4838-a02a-2259a9f858e0)

Insights from the above will be captured in seperate documentation
