### PR TITLE
[BAU] ignore non-Submit roles during authentication

### DIFF
--- a/app/main/authorisation.py
+++ b/app/main/authorisation.py
@@ -35,7 +35,11 @@ class AuthBase(ABC):
 
     @abstractmethod
     def get_auth_dict(self) -> dict:
-        """Return other details associated with this authorisation."""
+        """Return other details associated with this authorisation.
+
+        These are checked against fields in the submitted data. If they don't match up then the submission will be
+            rejected.
+        """
         pass
 
 

--- a/app/main/decorators.py
+++ b/app/main/decorators.py
@@ -57,24 +57,24 @@ def auth_required(func):
     def check_roles(roles: list[str]) -> str:
         """Checks the roles assigned to a user and returns the role if valid.
 
-        This function checks if a user has been assigned any roles, if the user has been assigned more than one role,
-        and if the assigned role is supported. If any of these checks fail, an error is logged and a 401 error is
-        returned.
-        If all checks pass, the function returns the assigned role.
+        This function checks if a user has been assigned:
+            - any Submit roles
+            - more than one Submit role.
+
+        If any of these checks fail, an error is logged and a 401 error is returned. Otherwise, returns the assigned
+        role.
 
         :param roles: A list of roles assigned to a user.
         :return: The role assigned to the user.
         :raises 401 Unauthorized: If the user has not been assigned any roles, has multiple roles, or does not have a
             supported role.
         """
-        if not roles:
-            current_app.logger.error(f"User: {g.user.email} has not been assigned any roles")
+        relevant_roles = set(roles).intersection(set(current_app.config["FUND_CONFIGS"].get_valid_roles()))
+        if not relevant_roles:
+            current_app.logger.error(f"User: {g.user.email} has not been assigned any Submit roles")
             abort(401)
-        elif len(roles) > 1:
-            current_app.logger.error(f"User: {g.user.email} has multiple roles, {roles}")
-            abort(401)
-        elif roles[0] not in current_app.config["FUND_CONFIGS"].get_valid_roles():
-            current_app.logger.error(f"User: {g.user.email}'s role, {roles}, is not a supported role")
+        elif len(relevant_roles) > 1:
+            current_app.logger.error(f"User: {g.user.email} has multiple Submit roles, {roles}")
             abort(401)
         else:
             return roles[0]

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -17,7 +17,6 @@ from app.const import (
 from app.main import bp
 from app.main.data_requests import post_ingest
 from app.main.decorators import auth_required
-from app.main.fund import TOWNS_FUND_APP_CONFIG
 from app.main.notify import send_confirmation_emails
 from app.utils import days_between_dates, is_load_enabled
 from config import Config
@@ -38,7 +37,7 @@ def login():
 
 
 @bp.route("/upload", methods=["GET", "POST"])
-@login_required(return_app=SupportedApp.POST_AWARD_SUBMIT, roles_required=[TOWNS_FUND_APP_CONFIG.user_role])
+@login_required(return_app=SupportedApp.POST_AWARD_SUBMIT)
 @auth_required
 def upload():
     if request.method == "GET":


### PR DESCRIPTION
### Change description
Previously, we checked to see if a user had multiple Azure AD roles, and if they did then they would be given 401.

This has been changed because users should be allowed to have multiple Azure AD roles, as long as there isn't more than one role relevant to Submit (Submit only supports a single fund per user at the moment).

This changes the authentication code to match this logic.

- [X] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
