### PR TITLE
BAU: increase log retention period to 90 days

### DIFF
--- a/copilot/submit/overrides/README.md
+++ b/copilot/submit/overrides/README.md
@@ -1,0 +1,17 @@
+# Overriding Copilot generated CloudFormation templates with YAML Patches
+
+The file `cfn.patches.yml` contains a list of YAML/JSON patches to apply to
+your template before AWS Copilot deploys it.
+
+To view examples and an explanation of how YAML patches work, check out the [documentation](https://aws.github.io/copilot-cli/docs/developing/overrides/yamlpatch).
+
+Note only [`add`](https://www.rfc-editor.org/rfc/rfc6902#section-4.1),
+[`remove`](https://www.rfc-editor.org/rfc/rfc6902#section-4.2), and
+[`replace`](https://www.rfc-editor.org/rfc/rfc6902#section-4.3)
+operations are supported by Copilot.
+Patches are applied in the order specified in the file.
+
+## Troubleshooting
+
+* `copilot [noun] package` preview the transformed template by writing to stdout.
+* `copilot [noun] package --diff` show the difference against the template deployed in your environment.

--- a/copilot/submit/overrides/cfn.patches.yml
+++ b/copilot/submit/overrides/cfn.patches.yml
@@ -1,0 +1,19 @@
+# Delete the task role resource
+# - op: remove
+#   path: /Resources/TaskRole
+
+# Add a service connect alias
+# - op: add
+#   path: /Resources/Service/Properties/ServiceConnectConfiguration/Services/0/ClientAliases/-
+#   value:
+#     Port: !Ref TargetPort
+#     DnsName: yamlpatchiscool
+
+# Replace the task role in the task definition
+# - op: replace
+#   path: /Resources/TaskDefinition/Properties/TaskRoleArn
+#   value: arn:aws:iam::123456789012:role/MyTaskRole
+
+- op: replace
+  path: /Resources/LogGroup/Properties/RetentionInDays
+  value: 90


### PR DESCRIPTION
### Change description
As part of: https://github.com/communitiesuk/funding-service-design-post-award-submit/pull/125 we found it would be useful to have logs going back a longer period. Extending the log retention period is the easiest way of doing this.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Can check retention period in AWS console following deployment

### Screenshots of UI changes (if applicable)
