### PR TITLE
[BAU] allow a user to be associated with multiple funds as long as only one is active

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,8 +8,8 @@ from jinja2 import ChoiceLoader, PackageLoader, PrefixLoader
 
 import static_assets
 from app.const import TOWNS_FUND_AUTH
-from app.main.authorisation import AuthMapping, ReadOnlyAuthMappings
-from app.main.fund import TOWNS_FUND_APP_CONFIG, FundConfig, ReadOnlyFundConfigs
+from app.main.authorisation import AuthMapping, AuthService
+from app.main.fund import TOWNS_FUND_APP_CONFIG, FundConfig, FundService
 from config import Config
 
 assets = Environment()
@@ -84,12 +84,12 @@ def setup_funds_and_auth(app: Flask) -> None:
 
     # funds
     towns_fund: FundConfig = TOWNS_FUND_APP_CONFIG
-    app.config["FUND_CONFIGS"] = ReadOnlyFundConfigs(role_to_fund_configs={towns_fund.user_role: towns_fund})
+    app.config["FUND_CONFIGS"] = FundService(role_to_fund_configs={towns_fund.user_role: towns_fund})
 
     # auth
     tf_auth = TOWNS_FUND_AUTH
     tf_auth.update(Config.ADDITIONAL_EMAIL_LOOKUPS)
-    app.config["AUTH_MAPPINGS"] = ReadOnlyAuthMappings(
+    app.config["AUTH_MAPPINGS"] = AuthService(
         fund_to_auth_mappings={towns_fund.fund_name: AuthMapping(towns_fund.auth_class, tf_auth)}
     )
 

--- a/app/main/authorisation.py
+++ b/app/main/authorisation.py
@@ -77,13 +77,13 @@ class AuthMapping:
         return auth
 
 
-class ReadOnlyAuthMappings:
-    """Read-only dictionary wrapper for storing authorisation mappings."""
+class AuthService:
+    """Authorisation Service - given a fund and an email address, will return the associated submission permissions."""
 
     def __init__(self, fund_to_auth_mappings: dict[str, AuthMapping]):
         self._auth_mappings = fund_to_auth_mappings
 
-    def get(self, fund: str) -> AuthMapping:
+    def get_auth(self, fund: str) -> AuthMapping:
         """Retrieves the authentication mapping for a given fund.
 
         :param fund: A fund name.

--- a/app/main/fund.py
+++ b/app/main/fund.py
@@ -69,30 +69,25 @@ class FundConfig:
         self.current_deadline = current_deadline
 
 
-class ReadOnlyFundConfigs:
-    """Read-only dictionary wrapper for storing fund configurations."""
+class FundService:
+    """Stores and exposes Fund information. Given a user's roles, will return the associated Fund information."""
 
     def __init__(self, role_to_fund_configs: dict[str, FundConfig]):
         self._fund_configs = role_to_fund_configs
 
-    def get(self, role: str):
-        """Retrieves the application configuration data associated with a user role.
+    def get_active_funds(self, roles: list[str]):
+        """Retrieves the active fund configuration data associated with a user role.
 
-        :param role: The user role.
-        :return: The configuration corresponding to the given role.
+        :param roles: The user roles.
+        :return: The configurations corresponding to the given roles.
         :raises ValueError: If the given role is not found in the application configurations.
         """
-        role = self._fund_configs.get(role)
-        if not role:
-            raise ValueError(f"Unknown user role {role}")
-        return role
-
-    def get_valid_roles(self):
-        """Returns the list of valid user roles.
-
-        :return: valid user roles
-        """
-        return list(self._fund_configs.keys())
+        funds = [
+            self._fund_configs[role]
+            for role in roles
+            if self._fund_configs.get(role) and self._fund_configs[role].active
+        ]
+        return funds
 
 
 TOWNS_FUND_APP_CONFIG = FundConfig(

--- a/tests/test_authorisation.py
+++ b/tests/test_authorisation.py
@@ -3,7 +3,7 @@ import pytest
 from app.main.authorisation import (
     AuthBase,
     AuthMapping,
-    ReadOnlyAuthMappings,
+    AuthService,
     validate_auth_args,
 )
 
@@ -40,8 +40,8 @@ def mock_auth_mapping(mock_auth_class, mock_mapping):
 
 
 @pytest.fixture
-def mock_auth_mappings(mock_auth_mapping):
-    return ReadOnlyAuthMappings(fund_to_auth_mappings={"Test Fund": mock_auth_mapping})
+def mock_auth_service(mock_auth_mapping):
+    return AuthService(fund_to_auth_mappings={"Test Fund": mock_auth_mapping})
 
 
 def test_auth_mapping_email_match(mock_auth_mapping, mock_auth_class):
@@ -107,16 +107,16 @@ def test_auth_mapping_no_match(mock_auth_mapping, mock_auth_class):
     assert auth is None
 
 
-def test_get_auth_mapping_retrieves_auth_mapping(mock_auth_mappings, mock_auth_class):
-    auth_mappings = mock_auth_mappings.get("Test Fund")
+def test_get_auth_mapping_retrieves_auth_mapping(mock_auth_service, mock_auth_class):
+    auth_mappings = mock_auth_service.get_auth("Test Fund")
 
     assert auth_mappings
     assert auth_mappings._auth_class == mock_auth_class
 
 
-def test_get_non_existent_auth_mapping_raises_value_error(mock_auth_mappings):
+def test_get_non_existent_auth_mapping_raises_value_error(mock_auth_service):
     with pytest.raises(ValueError):
-        mock_auth_mappings.get("Non-existent Fund")
+        mock_auth_service.get_auth("Non-existent Fund")
 
 
 def test_validate_auth_args_valid(mock_auth_class):

--- a/tests/test_fund.py
+++ b/tests/test_fund.py
@@ -4,12 +4,12 @@ from copy import copy
 import pytest
 
 from app.main.authorisation import AuthBase
-from app.main.fund import FundConfig, ReadOnlyFundConfigs
+from app.main.fund import FundConfig, FundService
 
 
 @pytest.fixture
-def test_fund_configs():
-    return ReadOnlyFundConfigs(
+def test_fund_service():
+    return FundService(
         role_to_fund_configs={
             "Test Role": FundConfig(
                 fund_name="Test Fund Name",
@@ -25,16 +25,25 @@ def test_fund_configs():
     )
 
 
-def test_get_fund_config_retrieves_fund_config(test_fund_configs):
-    fund_config = test_fund_configs.get("Test Role")
+def test_get_active_funds_retrieves_active_fund_config(test_fund_service):
+    fund_configs = test_fund_service.get_active_funds(["Test Role"])
 
-    assert fund_config
-    assert fund_config.fund_name == "Test Fund Name"
+    assert fund_configs
+    assert len(fund_configs) == 1
+    assert fund_configs[0].fund_name == "Test Fund Name"
 
 
-def test_get_fund_config_raises_value_error(test_fund_configs):
-    with pytest.raises(ValueError):
-        test_fund_configs.get("Non-existent Role")
+def test_get_active_funds_does_not_retrieve_inactive_fund_config(test_fund_service):
+    test_fund_service._fund_configs["Test Role"].active = False
+    fund_configs = test_fund_service.get_active_funds(["Test Role"])
+
+    assert not fund_configs
+
+
+def test_get_active_funds_raises_value_error(test_fund_service):
+    fund_configs = test_fund_service.get_active_funds(["Non-existent Role"])
+
+    assert not fund_configs
 
 
 def test_fund_config_validations():


### PR DESCRIPTION
Previously, we checked a users roles against a set of roles linked to funds and raised an exception if they had more than 1 "relevant role" associated with a fund.

Instead, we now allow a user to have a set of roles associated with multiple funds as long as only **one** is active.

This change also removes some buggy code in the `check_roles` function that has now been removed in place of checking
 the resulting funds instead.

- [X] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
