### PR TITLE
BAU: Fix excel filename not being passed to ingest

### DIFF
--- a/app/main/data_requests.py
+++ b/app/main/data_requests.py
@@ -18,7 +18,7 @@ def post_ingest(file: FileStorage, data: dict = None) -> tuple[dict | None, dict
     :return: A tuple of: True if the request was successful, pre_transformation_errors, validation_errors, metadata
     """
     request_url = Config.DATA_STORE_API_HOST + "/ingest"
-    files = {"excel_file": (file.name, file, MIMETYPE.XLSX)}
+    files = {"excel_file": (file.filename, file, MIMETYPE.XLSX)}
 
     current_app.logger.info(f"Sending POST to {request_url}")
     try:


### PR DESCRIPTION
### Change description
Fix excel filename not being passed to ingest and add test to cover this behaviour and assert filename passed correctly in request.

- [X] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
