### PR TITLE
SMD-615: add debug user for local development

### DIFF
--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -42,3 +42,11 @@ class DevelopmentConfig(DefaultConfig):
     # do not attempt to send confirmation email if development and no key is set
     SEND_CONFIRMATION_EMAILS = True if DefaultConfig.NOTIFY_API_KEY else False
     AUTO_BUILD_ASSETS = True
+
+    DEBUG_USER_ON = True
+    DEBUG_USER = {
+        "full_name": "Development User",
+        "email": "dev@communities.gov.uk",
+        "roles": ["TF_MONITORING_RETURN_SUBMITTER"],
+        "highest_role_map": {},
+    }


### PR DESCRIPTION
### Change description
Overrides auth when running in development, using the existing override functionality in the `@login_required` decorator

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
When running locally, you should be able to access `/upload` without going through Microsoft auth

### Screenshots of UI changes (if applicable)
