### PR TITLE
BAU: add basic auth on dev

### DIFF
--- a/copilot/submit/manifest.yml
+++ b/copilot/submit/manifest.yml
@@ -75,6 +75,23 @@ environments:
       healthcheck:
         path: /healthcheck
         port: 8080
+  dev:
+    sidecars:
+      nginx:
+        port: 8087
+        image:
+          location: xscys/nginx-sidecar-basic-auth
+        variables:
+          FORWARD_PORT: 8080
+          CLIENT_MAX_BODY_SIZE: 10m
+        secrets:
+          BASIC_AUTH_USERNAME: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_USERNAME
+          BASIC_AUTH_PASSWORD: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_PASSWORD
+    http:
+      target_container: nginx
+      healthcheck:
+        path: /healthcheck
+        port: 8080
 
 # You can override any of the values defined above by environment.
 #environments:


### PR DESCRIPTION
### Change description
Previously we had basic auth on test but not dev, this adds basic auth on dev.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Basic auth should be enabled on the dev environment


### Screenshots of UI changes (if applicable)
