### PR TITLE
SMD-650 - Enable confirmation emails on upload for Pathfinders

### DIFF
--- a/app/main/fund.py
+++ b/app/main/fund.py
@@ -99,7 +99,6 @@ TOWNS_FUND_APP_CONFIG = FundConfig(
     current_reporting_period="April to September 2023",
     current_reporting_round=4,
     current_deadline=datetime.date(day=4, month=12, year=2023),
-    # TODO: retrieval of email from secret is currently TF specific, modify to be more extendable
     email=Config.TF_CONFIRMATION_EMAIL_ADDRESS,
     active=True,
     auth_class=TFAuth,

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -109,8 +109,7 @@ def upload(fund_code, round):
             return render_template("validation-errors.html", validation_errors=validation_errors, fund=fund)
         else:
             # Success
-            # TODO: enable confirmation emails for PF once template changes are confirmed
-            if Config.SEND_CONFIRMATION_EMAILS and fund.fund_name != "Pathfinders":
+            if Config.SEND_CONFIRMATION_EMAILS:
                 send_confirmation_emails(
                     excel_file,
                     fund=fund.fund_name,


### PR DESCRIPTION
### Ticket
[SMD-650 - Pathfinders - enable confirmation emails on successful ingest](https://dluhcdigital.atlassian.net/browse/SMD-650)

### Change summary
Now that we have added the email address for Pathfinders to the AWS secrets, we can remove the conditional logic blocking email confirmation on Pathfinders spreadsheet ingest.