### PR TITLE
BAU: add extra local authorities devs can submit for pf

### DIFF
--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -42,7 +42,10 @@ class DevelopmentConfig(DefaultConfig):
     }
 
     PF_ADDITIONAL_EMAIL_LOOKUPS = {
-        domain: (("Rotherham Metropolitan Borough Council",),)
+        domain: (
+            ("Rotherham Metropolitan Borough Council", "Bolton Council", "Wirral Council"),
+            ("Rotherham", "Bolton", "Birkenhead", "New Ferry"),
+        )
         for domain in ("version1.com", "communities.gov.uk", "test.communities.gov.uk")
     }
 


### PR DESCRIPTION
Adds Bolton Council and Wirral Council as local authorities devs can submit for the purposes of testing.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
