### PR TITLE
BAU - Add PF to FUND_TYPE_ID_TO_FRIENDLY_NAME mapping

### DIFF
--- a/app/const.py
+++ b/app/const.py
@@ -14,6 +14,7 @@ class MIMETYPE(StrEnum):
 FUND_TYPE_ID_TO_FRIENDLY_NAME = {
     "TD": "Town Deal",
     "HS": "Future High Streets Fund",
+    "PF": "Pathfinders",
 }
 
 # domain/email: (LAs, Places)


### PR DESCRIPTION
Prevents error [Unknown fund type id found: PF](https://funding-service-design-team-dl.sentry.io/issues/5106056990/?referrer=slack&notification_uuid=8675e922-9f16-4351-9c49-37cb06a27365&alert_rule_id=14718986&alert_type=issue) on PF spreadsheet ingest.