### PR TITLE
BAU: fix Bolton Council name to match spreadsheet

### DIFF
--- a/app/const.py
+++ b/app/const.py
@@ -44,7 +44,7 @@ DOMAIN_TO_LA_PLACES = {
         ("Blackpool",),
     ),
     "bolton.gov.uk": (
-        ("Bolton Metropolitan Borough Council",),
+        ("Bolton Council",),
         ("Farnworth", "Bolton"),
     ),
     "boston.gov.uk": (


### PR DESCRIPTION

### Change description
fix Bolton Council name to match spreadsheet. See discussion on Slack for further context. This is safe because no data has been submitted under the previously defined name.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
User should be allowed to upload Bolton spreadsheet as currently defined.


### Screenshots of UI changes (if applicable)
