### PR TITLE
Persist submitting user metadata

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -46,6 +46,8 @@ def upload(fund_code, round):
 
     fund = g.access[fund_code].fund
     auth = g.access[fund_code].auth
+    submitting_account_id = g.account_id
+    submitting_user_email = g.user.email
 
     if request.method == "GET":
         return render_template(
@@ -71,6 +73,8 @@ def upload(fund_code, round):
                     "reporting_round": fund.current_reporting_round,
                     "auth": json.dumps(auth.get_auth_dict()),
                     "do_load": is_load_enabled(),
+                    "submitting_account_id": submitting_account_id,
+                    "submitting_user_email": submitting_user_email,
                 },
             )
 

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -59,4 +59,7 @@ class DevelopmentConfig(DefaultConfig):
         "roles": ["PF_MONITORING_RETURN_SUBMITTER", "TF_MONITORING_RETURN_SUBMITTER"],
         "highest_role_map": {},
     }
+
+    DEBUG_USER_ACCOUNT_ID = "00000000-0000-0000-0000-000000000000"
+
     ENABLE_TF_R5 = True


### PR DESCRIPTION
Ticket:
https://dluhcdigital.atlassian.net/browse/FMD-251


Description:
On submission passes user's account_id and email address to data-store/ingest. 

DEBUG_USER_ACCOUNT_ID is added to config/envs/development.py to be able to test locally.

