### PR TITLE
Pull in latest fsd_utils and upgrade sentry

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -111,11 +111,9 @@ flipper-client==1.3.2
     # via
     #   -r requirements.txt
     #   funding-service-design-utils
-funding-service-design-utils==2.0.32
+funding-service-design-utils==3.0.1
     # via -r requirements.txt
 govuk-frontend-jinja==2.7.0
-    # via -r requirements.txt
-greenlet==3.0.3
     # via -r requirements.txt
 gunicorn==20.1.0
     # via
@@ -259,7 +257,7 @@ s3transfer==0.6.1
     # via
     #   -r requirements.txt
     #   boto3
-sentry-sdk[flask]==1.29.2
+sentry-sdk[flask]==2.8.0
     # via
     #   -r requirements.txt
     #   funding-service-design-utils

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-funding-service-design-utils==2.0.32
+funding-service-design-utils
 notifications-python-client==8.1.0
 cssmin==0.2.0
 jsmin==3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -68,12 +68,10 @@ flask-sqlalchemy==3.0.5
     #   funding-service-design-utils
 flipper-client==1.3.2
     # via funding-service-design-utils
-funding-service-design-utils==2.0.32
+funding-service-design-utils==3.0.1
     # via -r requirements.in
 govuk-frontend-jinja==2.7.0
     # via -r requirements.in
-greenlet==3.0.3
-    # via sqlalchemy
 gunicorn==20.1.0
     # via
     #   -r requirements.in
@@ -113,7 +111,6 @@ pyjwt[crypto]==2.8.0
     # via
     #   funding-service-design-utils
     #   notifications-python-client
-    #   pyjwt
 python-consul==1.1.0
     # via flipper-client
 python-dateutil==2.8.2
@@ -141,10 +138,8 @@ rich==12.6.0
     # via funding-service-design-utils
 s3transfer==0.6.1
     # via boto3
-sentry-sdk[flask]==1.29.2
-    # via
-    #   funding-service-design-utils
-    #   sentry-sdk
+sentry-sdk[flask]==2.8.0
+    # via funding-service-design-utils
 six==1.16.0
     # via
     #   python-consul


### PR DESCRIPTION
### Change description
Pull in latest fsd_utils, so that we can use the latest version of sentry.