### PR TITLE
BAU: Add new email domain to LA mapping

### DIFF
--- a/app/const.py
+++ b/app/const.py
@@ -50,6 +50,10 @@ DOMAIN_TO_LA_PLACES = {
         ("Bradford Council",),
         ("Shipley", "Keighley"),
     ),
+    "bromsgroveandredditch.gov.uk": (
+        ("Redditch Borough Council",),
+        ("Redditch",),
+    ),
     "broxtowe.gov.uk": (
         ("Broxtowe Borough Council",),
         ("Stapleford",),


### PR DESCRIPTION
### Change description
Adds `bromsgroveandredditch.gov.uk` to the `DOMAIN_TO_LA_PLACES` mapping, as per TF support request.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
